### PR TITLE
feat(s3d-loader): add s3d-loader crate — assetsStrategy / strategyAssets — Closes #5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "assert-json-diff"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -27,6 +37,18 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bitflags"
@@ -54,10 +76,57 @@ dependencies = [
 ]
 
 [[package]]
+name = "bumpalo"
+version = "3.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
+name = "bytes"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+
+[[package]]
+name = "cc"
+version = "1.2.57"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a0dd1ca384932ff3641c8718a02769f1698e7563dc6974ffd03346116310423"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "colored"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
@@ -89,6 +158,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "displaydoc"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -111,10 +191,134 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
 name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+
+[[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
+name = "futures"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
+ "futures-task",
+ "memchr",
+ "pin-project-lite",
+ "slab",
+]
 
 [[package]]
 name = "generic-array"
@@ -128,13 +332,25 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 6.0.0",
  "wasip2",
  "wasip3",
 ]
@@ -150,6 +366,25 @@ dependencies = [
  "log",
  "regex-automata",
  "regex-syntax",
+]
+
+[[package]]
+name = "h2"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
 ]
 
 [[package]]
@@ -180,10 +415,219 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "http"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+dependencies = [
+ "bytes",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+dependencies = [
+ "bytes",
+ "http",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "hyper"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "h2",
+ "http",
+ "http-body",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "pin-utils",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
+dependencies = [
+ "bytes",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "ipnet",
+ "libc",
+ "percent-encoding",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "icu_collections"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
+
+[[package]]
+name = "icu_properties"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
+
+[[package]]
+name = "icu_provider"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
 name = "id-arena"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
 
 [[package]]
 name = "indexmap"
@@ -198,10 +642,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "ipnet"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+
+[[package]]
+name = "iri-string"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c91338f0783edbd6195decb37bae672fd3b165faffb89bf7b9e6942f8b1a731a"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "js-sys"
+version = "0.3.91"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
+dependencies = [
+ "once_cell",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "leb128fmt"
@@ -220,6 +690,21 @@ name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
+name = "litemap"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
+
+[[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
 
 [[package]]
 name = "log"
@@ -250,16 +735,172 @@ dependencies = [
 ]
 
 [[package]]
+name = "mio"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
+dependencies = [
+ "libc",
+ "wasi",
+ "windows-sys",
+]
+
+[[package]]
+name = "mockito"
+version = "1.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90820618712cab19cfc46b274c6c22546a82affcb3c3bdf0f29e3db8e1bb92c0"
+dependencies = [
+ "assert-json-diff",
+ "bytes",
+ "colored",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "log",
+ "pin-project-lite",
+ "rand",
+ "regex",
+ "serde_json",
+ "serde_urlencoded",
+ "similar",
+ "tokio",
+]
+
+[[package]]
+name = "native-tls"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
+dependencies = [
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
+name = "openssl"
+version = "0.10.76"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "951c002c75e16ea2c65b8c7e4d3d51d5530d8dfa7d060b4776828c88cfb18ecf"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.112"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57d55af3b3e226502be1526dfdba67ab0e9c96fc293004e79576b2b9edb0dbdb"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-link",
+]
+
+[[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "potential_utf"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
+dependencies = [
+ "zerovec",
+]
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
 
 [[package]]
 name = "prettyplease"
@@ -291,9 +932,65 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+dependencies = [
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "regex"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
 
 [[package]]
 name = "regex-automata"
@@ -313,6 +1010,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
+name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-tls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "native-tls",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-native-tls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -326,6 +1059,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-pki-types"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
 name = "s3d-deploy"
 version = "0.1.0"
 dependencies = [
@@ -337,8 +1091,24 @@ dependencies = [
  "serde_json",
  "sha2",
  "tempfile",
- "thiserror",
+ "thiserror 2.0.18",
  "walkdir",
+]
+
+[[package]]
+name = "s3d-loader"
+version = "0.1.0"
+dependencies = [
+ "futures",
+ "hex",
+ "mockito",
+ "reqwest",
+ "s3d-types",
+ "serde",
+ "serde_json",
+ "sha2",
+ "thiserror 1.0.69",
+ "tokio",
 ]
 
 [[package]]
@@ -358,6 +1128,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -410,6 +1218,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -419,6 +1239,46 @@ dependencies = [
  "cpufeatures",
  "digest",
 ]
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "similar"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
+
+[[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
+name = "smallvec"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "socket2"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "syn"
@@ -432,16 +1292,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
  "windows-sys",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
 ]
 
 [[package]]
@@ -450,7 +1339,18 @@ version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.18",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -465,13 +1365,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinystr"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
+
+[[package]]
 name = "tokio"
 version = "1.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
 dependencies = [
+ "bytes",
+ "libc",
+ "mio",
+ "parking_lot",
  "pin-project-lite",
+ "socket2",
  "tokio-macros",
+ "windows-sys",
 ]
 
 [[package]]
@@ -484,6 +1400,99 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "tower"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "iri-string",
+ "pin-project-lite",
+ "tower",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
+
+[[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+dependencies = [
+ "pin-project-lite",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "typenum"
@@ -510,6 +1519,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -524,6 +1557,21 @@ dependencies = [
  "same-file",
  "winapi-util",
 ]
+
+[[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
+]
+
+[[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
@@ -541,6 +1589,65 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
  "wit-bindgen",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.114"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6532f9a5c1ece3798cb1c2cfdba640b9b3ba884f5db45973a6f442510a87d38e"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9c5522b3a28661442748e09d40924dfb9ca614b21c00d3fd135720e48b67db8"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "js-sys",
+ "once_cell",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.114"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18a2d50fcf105fb33bb15f00e7a77b772945a2ee45dcf454961fd843e74c18e6"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.114"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03ce4caeaac547cdf713d280eda22a730824dd11e6b8c3ca9e42247b25c631e3"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.114"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
+dependencies = [
+ "unicode-ident",
 ]
 
 [[package]]
@@ -575,6 +1682,16 @@ dependencies = [
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.91"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -687,6 +1804,115 @@ dependencies = [
  "serde_json",
  "unicode-xid",
  "wasmparser",
+]
+
+[[package]]
+name = "writeable"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+
+[[package]]
+name = "yoke"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efbb2a062be311f2ba113ce66f697a4dc589f85e78a4aea276200804cea0ed87"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e8bc7269b54418e7aeeef514aa68f8690b8c0489a06b0136e5f57c4c5ccab89"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "zeroize"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+
+[[package]]
+name = "zerotrie"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/crates/s3d-loader/Cargo.toml
+++ b/crates/s3d-loader/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "s3d-loader"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+s3d-types = { path = "../s3d-types" }
+sha2 = "0.10"
+hex = "0.4"
+reqwest = { version = "0.12", default-features = false, features = ["json", "native-tls"] }
+tokio = { version = "1", features = ["rt", "rt-multi-thread", "sync", "time", "macros"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+thiserror = "1"
+futures = "0.3"
+
+[dev-dependencies]
+tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros", "time"] }
+mockito = "1"
+hex = "0.4"

--- a/crates/s3d-loader/src/cache.rs
+++ b/crates/s3d-loader/src/cache.rs
@@ -1,0 +1,174 @@
+//! インメモリキャッシュ制御モジュール
+//!
+//! `manifest` のアセットハッシュをキーにバイト列を保持する。
+//! ブラウザの Cache API の代わりに、ネイティブ・Wasm 両環境で動く
+//! シンプルな `HashMap` ベースのキャッシュを提供する。
+//!
+//! ## 設計方針
+//! - キー: マニフェストのアセットキー（例: `"js/main.js"`）
+//! - ハッシュが一致 → キャッシュヒット（ネットワーク取得スキップ）
+//! - ハッシュが変化 → 古エントリを削除し新エントリを保存
+//! - Service Worker 不使用・フレームワーク非依存
+
+use std::collections::HashMap;
+
+// ─────────────────────────────────────────────
+// キャッシュエントリ
+// ─────────────────────────────────────────────
+
+/// キャッシュに保存されるアセットの1エントリ
+#[derive(Debug, Clone)]
+pub struct CacheEntry {
+    /// アセットハッシュ（hex）—— キャッシュ有効性の判定に使う
+    pub hash: String,
+    /// レスポンスボディ（bytes）
+    pub data: Vec<u8>,
+}
+
+// ─────────────────────────────────────────────
+// AssetCache
+// ─────────────────────────────────────────────
+
+/// インメモリアセットキャッシュ
+///
+/// スレッドセーフにしたい場合は `Arc<Mutex<AssetCache>>` でラップする。
+#[derive(Debug, Default)]
+pub struct AssetCache {
+    store: HashMap<String, CacheEntry>,
+}
+
+impl AssetCache {
+    /// 新しい空のキャッシュを作成する
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// キャッシュヒット判定
+    ///
+    /// 指定キーのエントリが存在し、かつハッシュが一致すれば `Some(&[u8])` を返す。
+    pub fn get(&self, key: &str, hash: &str) -> Option<&[u8]> {
+        self.store.get(key).and_then(|e| {
+            if e.hash == hash {
+                Some(e.data.as_slice())
+            } else {
+                None
+            }
+        })
+    }
+
+    /// エントリを保存する
+    ///
+    /// 同じキーの古いエントリは自動的に上書き（削除 + 追加）される。
+    pub fn put(&mut self, key: String, hash: String, data: Vec<u8>) {
+        self.store.insert(key, CacheEntry { hash, data });
+    }
+
+    /// 指定キーのエントリを削除する
+    pub fn evict(&mut self, key: &str) {
+        self.store.remove(key);
+    }
+
+    /// 古いハッシュのエントリをすべて削除する
+    ///
+    /// `current_hashes` に含まれないキー、または含まれていてもハッシュが
+    /// 異なるエントリを削除する。新しい manifest への移行後に呼ぶ。
+    pub fn evict_stale(&mut self, current_hashes: &HashMap<String, String>) {
+        self.store.retain(|key, entry| {
+            current_hashes
+                .get(key)
+                .map(|h| h == &entry.hash)
+                .unwrap_or(false)
+        });
+    }
+
+    /// キャッシュに含まれるエントリ数
+    pub fn len(&self) -> usize {
+        self.store.len()
+    }
+
+    /// キャッシュが空かどうか
+    pub fn is_empty(&self) -> bool {
+        self.store.is_empty()
+    }
+}
+
+// ─────────────────────────────────────────────
+// Tests
+// ─────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cache_hit_on_matching_hash() {
+        let mut cache = AssetCache::new();
+        cache.put(
+            "js/main.js".to_string(),
+            "abc".to_string(),
+            b"data".to_vec(),
+        );
+
+        let hit = cache.get("js/main.js", "abc");
+        assert_eq!(hit, Some(b"data".as_slice()));
+    }
+
+    #[test]
+    fn cache_miss_on_hash_mismatch() {
+        let mut cache = AssetCache::new();
+        cache.put(
+            "js/main.js".to_string(),
+            "abc".to_string(),
+            b"data".to_vec(),
+        );
+
+        // ハッシュが変わったらミス
+        assert!(cache.get("js/main.js", "xyz").is_none());
+    }
+
+    #[test]
+    fn cache_miss_on_unknown_key() {
+        let cache = AssetCache::new();
+        assert!(cache.get("not/exist.js", "abc").is_none());
+    }
+
+    #[test]
+    fn cache_put_overwrites_old_entry() {
+        let mut cache = AssetCache::new();
+        cache.put("a.js".to_string(), "v1".to_string(), b"old".to_vec());
+        cache.put("a.js".to_string(), "v2".to_string(), b"new".to_vec());
+
+        assert!(cache.get("a.js", "v1").is_none());
+        assert_eq!(cache.get("a.js", "v2"), Some(b"new".as_slice()));
+    }
+
+    #[test]
+    fn evict_removes_entry() {
+        let mut cache = AssetCache::new();
+        cache.put("a.js".to_string(), "v1".to_string(), b"x".to_vec());
+        cache.evict("a.js");
+        assert!(cache.is_empty());
+    }
+
+    #[test]
+    fn evict_stale_removes_outdated_entries() {
+        let mut cache = AssetCache::new();
+        cache.put("a.js".to_string(), "v1".to_string(), b"a".to_vec());
+        cache.put("b.js".to_string(), "v2".to_string(), b"b".to_vec());
+        cache.put("c.js".to_string(), "v3".to_string(), b"c".to_vec());
+
+        // a.js は同じハッシュ → 残す
+        // b.js はハッシュ変化 → 削除
+        // c.js はキーなし → 削除
+        let mut current = HashMap::new();
+        current.insert("a.js".to_string(), "v1".to_string());
+        current.insert("b.js".to_string(), "v2_new".to_string());
+
+        cache.evict_stale(&current);
+
+        assert!(cache.get("a.js", "v1").is_some());
+        assert!(cache.get("b.js", "v2").is_none());
+        assert!(cache.get("c.js", "v3").is_none());
+        assert_eq!(cache.len(), 1);
+    }
+}

--- a/crates/s3d-loader/src/diff.rs
+++ b/crates/s3d-loader/src/diff.rs
@@ -1,0 +1,211 @@
+//! manifest 差分検知モジュール
+//!
+//! キャッシュ済みの旧 manifest と CDN から取得した新 manifest を比較し、
+//! 変更されたアセットだけを取得対象として返す。
+//!
+//! `s3d-deploy` の `diff.rs` はデプロイ時の比較（ファイルシステム → CDN）に対し、
+//! こちらはランタイム時のクライアント側での比較（キャッシュ → CDN manifest）。
+
+use std::collections::HashMap;
+
+use s3d_types::asset::AssetDiff;
+use s3d_types::manifest::DeployManifest;
+
+// ─────────────────────────────────────────────
+// DiffEntry
+// ─────────────────────────────────────────────
+
+/// manifest 差分の1エントリ
+#[derive(Debug, Clone, PartialEq)]
+pub struct DiffEntry {
+    /// マニフェストキー（例: `"js/main.js"`）
+    pub key: String,
+    /// 差分種別
+    pub diff: AssetDiff,
+    /// 新 manifest の URL（Deleted は None）
+    pub url: Option<String>,
+    /// 新 manifest のハッシュ（Deleted は None）
+    pub hash: Option<String>,
+    /// ファイルサイズ（Deleted は 0）
+    pub size: u64,
+}
+
+// ─────────────────────────────────────────────
+// diff_manifests
+// ─────────────────────────────────────────────
+
+/// 旧 manifest（キャッシュ）と新 manifest（CDN）を比較して差分リストを返す
+///
+/// - `old`: キャッシュ済みの manifest。`None` の場合は「初回デプロイ」扱い（全アセットが Added）
+/// - `new`: CDN から取得した最新 manifest
+pub fn diff_manifests(old: Option<&DeployManifest>, new: &DeployManifest) -> Vec<DiffEntry> {
+    let old_assets: HashMap<&str, _> = old
+        .map(|m| m.assets.iter().map(|(k, v)| (k.as_str(), v)).collect())
+        .unwrap_or_default();
+
+    let mut entries: Vec<DiffEntry> = Vec::new();
+
+    // 新 manifest を走査: Added / Modified / Unchanged を判定
+    for (key, new_entry) in &new.assets {
+        let diff = match old_assets.get(key.as_str()) {
+            None => AssetDiff::Added,
+            Some(old_entry) => {
+                if old_entry.hash == new_entry.hash {
+                    AssetDiff::Unchanged
+                } else {
+                    AssetDiff::Modified
+                }
+            }
+        };
+
+        entries.push(DiffEntry {
+            key: key.clone(),
+            diff,
+            url: Some(new_entry.url.clone()),
+            hash: Some(new_entry.hash.clone()),
+            size: new_entry.size,
+        });
+    }
+
+    // 旧 manifest にあって新 manifest にないもの → Deleted
+    for key in old_assets.keys() {
+        if !new.assets.contains_key(*key) {
+            entries.push(DiffEntry {
+                key: key.to_string(),
+                diff: AssetDiff::Deleted,
+                url: None,
+                hash: None,
+                size: 0,
+            });
+        }
+    }
+
+    // 安定した順序でソート（テストの再現性向上）
+    entries.sort_by(|a, b| a.key.cmp(&b.key));
+    entries
+}
+
+/// 取得が必要なエントリだけを返す（Added + Modified のみ）
+pub fn needs_fetch(entries: &[DiffEntry]) -> Vec<&DiffEntry> {
+    entries
+        .iter()
+        .filter(|e| matches!(e.diff, AssetDiff::Added | AssetDiff::Modified))
+        .collect()
+}
+
+/// キャッシュから削除すべきエントリだけを返す（Deleted + Modified）
+pub fn needs_evict(entries: &[DiffEntry]) -> Vec<&DiffEntry> {
+    entries
+        .iter()
+        .filter(|e| matches!(e.diff, AssetDiff::Deleted | AssetDiff::Modified))
+        .collect()
+}
+
+// ─────────────────────────────────────────────
+// Tests
+// ─────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use s3d_types::manifest::AssetEntry;
+
+    fn make_manifest(entries: Vec<(&str, &str, &str)>) -> DeployManifest {
+        let mut assets = HashMap::new();
+        for (key, url, hash) in entries {
+            assets.insert(
+                key.to_string(),
+                AssetEntry {
+                    url: url.to_string(),
+                    size: 100,
+                    hash: hash.to_string(),
+                    content_type: "application/javascript".to_string(),
+                    dependencies: None,
+                },
+            );
+        }
+        DeployManifest {
+            schema_version: 1,
+            version: "1.0.0".to_string(),
+            build_time: "2026-03-20T00:00:00Z".to_string(),
+            assets,
+        }
+    }
+
+    #[test]
+    fn first_deploy_all_added() {
+        let new = make_manifest(vec![
+            ("js/main.js", "https://cdn/js/main.abc.js", "abc"),
+            ("style.css", "https://cdn/style.xyz.css", "xyz"),
+        ]);
+        let entries = diff_manifests(None, &new);
+        assert!(entries.iter().all(|e| e.diff == AssetDiff::Added));
+        assert_eq!(entries.len(), 2);
+    }
+
+    #[test]
+    fn unchanged_files_detected() {
+        let old = make_manifest(vec![("js/main.js", "https://cdn/js/main.abc.js", "abc")]);
+        let new = make_manifest(vec![("js/main.js", "https://cdn/js/main.abc.js", "abc")]);
+        let entries = diff_manifests(Some(&old), &new);
+        assert_eq!(entries[0].diff, AssetDiff::Unchanged);
+    }
+
+    #[test]
+    fn modified_file_detected() {
+        let old = make_manifest(vec![("js/main.js", "https://cdn/js/main.abc.js", "abc")]);
+        let new = make_manifest(vec![("js/main.js", "https://cdn/js/main.def.js", "def")]);
+        let entries = diff_manifests(Some(&old), &new);
+        assert_eq!(entries[0].diff, AssetDiff::Modified);
+        assert_eq!(entries[0].hash, Some("def".to_string()));
+    }
+
+    #[test]
+    fn deleted_file_detected() {
+        let old = make_manifest(vec![
+            ("js/main.js", "https://cdn/js/main.abc.js", "abc"),
+            ("old.js", "https://cdn/old.xyz.js", "xyz"),
+        ]);
+        let new = make_manifest(vec![("js/main.js", "https://cdn/js/main.abc.js", "abc")]);
+        let entries = diff_manifests(Some(&old), &new);
+        let deleted: Vec<_> = entries
+            .iter()
+            .filter(|e| e.diff == AssetDiff::Deleted)
+            .collect();
+        assert_eq!(deleted.len(), 1);
+        assert_eq!(deleted[0].key, "old.js");
+    }
+
+    #[test]
+    fn needs_fetch_filters_added_and_modified() {
+        let old = make_manifest(vec![
+            ("a.js", "https://cdn/a.v1.js", "v1"),
+            ("b.js", "https://cdn/b.v1.js", "v1"),
+        ]);
+        let new = make_manifest(vec![
+            ("a.js", "https://cdn/a.v2.js", "v2"), // Modified
+            ("b.js", "https://cdn/b.v1.js", "v1"), // Unchanged
+            ("c.js", "https://cdn/c.v1.js", "v1"), // Added
+        ]);
+        let entries = diff_manifests(Some(&old), &new);
+        let fetch = needs_fetch(&entries);
+        assert_eq!(fetch.len(), 2);
+        let keys: Vec<&str> = fetch.iter().map(|e| e.key.as_str()).collect();
+        assert!(keys.contains(&"a.js"));
+        assert!(keys.contains(&"c.js"));
+    }
+
+    #[test]
+    fn needs_evict_filters_deleted_and_modified() {
+        let old = make_manifest(vec![
+            ("a.js", "https://cdn/a.v1.js", "v1"), // Modified
+            ("b.js", "https://cdn/b.v1.js", "v1"), // Deleted
+        ]);
+        let new = make_manifest(vec![
+            ("a.js", "https://cdn/a.v2.js", "v2"), // Modified
+        ]);
+        let entries = diff_manifests(Some(&old), &new);
+        let evict = needs_evict(&entries);
+        assert_eq!(evict.len(), 2);
+    }
+}

--- a/crates/s3d-loader/src/fetcher.rs
+++ b/crates/s3d-loader/src/fetcher.rs
@@ -1,0 +1,413 @@
+//! アセット取得コアモジュール
+//!
+//! 旧 TS の `AssetLoader` に相当する機能を Rust/async で実装する:
+//! - `manifest` の HTTP フェッチ（内部キャッシュ付き）
+//! - 並列ダウンロード（concurrency 制御）
+//! - SHA-256 整合性チェック
+//! - リトライ（指数バックオフ）
+//! - 進捗コールバック
+//! - `CancellationToken` によるキャンセル
+
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+
+use futures::stream::{self, StreamExt};
+use reqwest::Client;
+use sha2::{Digest, Sha256};
+use thiserror::Error;
+use tokio::sync::Mutex;
+
+use s3d_types::loader::{LoadError, LoadErrorKind};
+use s3d_types::manifest::DeployManifest;
+
+use crate::strategy::StrategyAsset;
+
+// ─────────────────────────────────────────────
+// FetchError
+// ─────────────────────────────────────────────
+
+/// fetcher モジュールのエラー型
+#[derive(Debug, Error)]
+pub enum FetchError {
+    #[error("HTTP error for `{key}` ({url}): {status}")]
+    Http {
+        key: String,
+        url: String,
+        status: u16,
+    },
+
+    #[error("Network error for `{key}` ({url}): {cause}")]
+    Network {
+        key: String,
+        url: String,
+        cause: String,
+    },
+
+    #[error("Integrity mismatch for `{key}`: expected {expected}, got {actual}")]
+    Integrity {
+        key: String,
+        expected: String,
+        actual: String,
+    },
+
+    #[error("Manifest fetch failed ({url}): {cause}")]
+    ManifestFetch { url: String, cause: String },
+
+    #[error("Manifest parse failed ({url}): {cause}")]
+    ManifestParse { url: String, cause: String },
+
+    #[error("Cancelled")]
+    Cancelled,
+}
+
+impl From<FetchError> for LoadError {
+    fn from(e: FetchError) -> Self {
+        match &e {
+            FetchError::Http { key, url, .. } => LoadError {
+                kind: LoadErrorKind::Network,
+                key: key.clone(),
+                url: url.clone(),
+                cause: Some(e.to_string()),
+                status_code: if let FetchError::Http { status, .. } = &e {
+                    Some(*status)
+                } else {
+                    None
+                },
+            },
+            FetchError::Network { key, url, .. } => LoadError {
+                kind: LoadErrorKind::Network,
+                key: key.clone(),
+                url: url.clone(),
+                cause: Some(e.to_string()),
+                status_code: None,
+            },
+            FetchError::Integrity { key, .. } => LoadError {
+                kind: LoadErrorKind::Integrity,
+                key: key.clone(),
+                url: String::new(),
+                cause: Some(e.to_string()),
+                status_code: None,
+            },
+            FetchError::Cancelled => LoadError {
+                kind: LoadErrorKind::Abort,
+                key: String::new(),
+                url: String::new(),
+                cause: Some("Cancelled".to_string()),
+                status_code: None,
+            },
+            _ => LoadError {
+                kind: LoadErrorKind::Unknown,
+                key: String::new(),
+                url: String::new(),
+                cause: Some(e.to_string()),
+                status_code: None,
+            },
+        }
+    }
+}
+
+// ─────────────────────────────────────────────
+// CancellationToken
+// ─────────────────────────────────────────────
+
+/// キャンセルシグナル（AbortSignal 相当）
+#[derive(Debug, Clone, Default)]
+pub struct CancellationToken {
+    cancelled: Arc<AtomicBool>,
+}
+
+impl CancellationToken {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// キャンセルをトリガーする
+    pub fn cancel(&self) {
+        self.cancelled.store(true, Ordering::SeqCst);
+    }
+
+    /// キャンセル済みか判定する
+    pub fn is_cancelled(&self) -> bool {
+        self.cancelled.load(Ordering::SeqCst)
+    }
+}
+
+// ─────────────────────────────────────────────
+// FetchOptions
+// ─────────────────────────────────────────────
+
+/// アセット取得のオプション
+#[derive(Debug, Clone)]
+pub struct FetchOptions {
+    /// 並列ダウンロード数（デフォルト: 4）
+    pub concurrency: usize,
+    /// リトライ回数（デフォルト: 3）
+    pub retry_count: u32,
+    /// リトライ基本遅延（ミリ秒、指数バックオフのベース、デフォルト: 500）
+    pub retry_base_delay_ms: u64,
+    /// タイムアウト（ミリ秒、デフォルト: 30_000）
+    pub timeout_ms: u64,
+    /// SHA-256 整合性チェックを有効にするか（デフォルト: true）
+    pub integrity_check: bool,
+}
+
+impl Default for FetchOptions {
+    fn default() -> Self {
+        Self {
+            concurrency: 4,
+            retry_count: 3,
+            retry_base_delay_ms: 500,
+            timeout_ms: 30_000,
+            integrity_check: true,
+        }
+    }
+}
+
+// ─────────────────────────────────────────────
+// ProgressEvent
+// ─────────────────────────────────────────────
+
+/// 進捗コールバックに渡されるイベント
+#[derive(Debug, Clone)]
+pub struct ProgressEvent {
+    pub key: String,
+    pub loaded_count: usize,
+    pub total_count: usize,
+}
+
+// ─────────────────────────────────────────────
+// Fetcher
+// ─────────────────────────────────────────────
+
+/// アセット取得コア
+///
+/// `reqwest::Client` を共有し、manifest キャッシュを内部に保持する。
+pub struct Fetcher {
+    client: Client,
+    opts: FetchOptions,
+    /// フェッチ済み manifest のインメモリキャッシュ（URL → DeployManifest）
+    manifest_cache: Mutex<std::collections::HashMap<String, DeployManifest>>,
+}
+
+impl Fetcher {
+    /// 新しい Fetcher を作成する
+    pub fn new(opts: FetchOptions) -> Self {
+        let client = Client::builder()
+            .timeout(Duration::from_millis(opts.timeout_ms))
+            .build()
+            .expect("failed to build reqwest client");
+
+        Self {
+            client,
+            opts,
+            manifest_cache: Mutex::new(std::collections::HashMap::new()),
+        }
+    }
+
+    /// manifest JSON を取得・パースし、内部キャッシュに保存する
+    pub async fn fetch_manifest(&self, url: &str) -> Result<DeployManifest, FetchError> {
+        {
+            let cache = self.manifest_cache.lock().await;
+            if let Some(m) = cache.get(url) {
+                return Ok(m.clone());
+            }
+        }
+
+        let resp = self
+            .client
+            .get(url)
+            .send()
+            .await
+            .map_err(|e| FetchError::ManifestFetch {
+                url: url.to_string(),
+                cause: e.to_string(),
+            })?;
+
+        if !resp.status().is_success() {
+            return Err(FetchError::ManifestFetch {
+                url: url.to_string(),
+                cause: format!("HTTP {}", resp.status()),
+            });
+        }
+
+        let manifest: DeployManifest =
+            resp.json().await.map_err(|e| FetchError::ManifestParse {
+                url: url.to_string(),
+                cause: e.to_string(),
+            })?;
+
+        self.manifest_cache
+            .lock()
+            .await
+            .insert(url.to_string(), manifest.clone());
+
+        Ok(manifest)
+    }
+
+    /// 内部 manifest キャッシュをクリアする（再フェッチ強制）
+    pub async fn invalidate_manifest_cache(&self, url: &str) {
+        self.manifest_cache.lock().await.remove(url);
+    }
+
+    /// 1アセットをリトライ付きでダウンロードし、整合性チェックを行う
+    async fn fetch_one(
+        &self,
+        key: &str,
+        url: &str,
+        expected_hash: &str,
+        token: &CancellationToken,
+    ) -> Result<Vec<u8>, FetchError> {
+        let mut attempt = 0u32;
+
+        loop {
+            if token.is_cancelled() {
+                return Err(FetchError::Cancelled);
+            }
+
+            match self.client.get(url).send().await {
+                Ok(resp) if resp.status().is_success() => {
+                    let data = resp.bytes().await.map_err(|e| FetchError::Network {
+                        key: key.to_string(),
+                        url: url.to_string(),
+                        cause: e.to_string(),
+                    })?;
+
+                    // SHA-256 整合性チェック
+                    if self.opts.integrity_check {
+                        let mut hasher = Sha256::new();
+                        hasher.update(&data);
+                        let actual = hex::encode(hasher.finalize());
+                        // expected_hash は任意長プレフィックス（8文字など）
+                        if !actual.starts_with(expected_hash) && actual != expected_hash {
+                            return Err(FetchError::Integrity {
+                                key: key.to_string(),
+                                expected: expected_hash.to_string(),
+                                actual: actual[..expected_hash.len().min(actual.len())].to_string(),
+                            });
+                        }
+                    }
+
+                    return Ok(data.to_vec());
+                }
+                Ok(resp) => {
+                    let status = resp.status().as_u16();
+                    // 4xx はリトライしない
+                    if status >= 400 && status < 500 {
+                        return Err(FetchError::Http {
+                            key: key.to_string(),
+                            url: url.to_string(),
+                            status,
+                        });
+                    }
+                    // 5xx はリトライ対象
+                    if attempt >= self.opts.retry_count {
+                        return Err(FetchError::Http {
+                            key: key.to_string(),
+                            url: url.to_string(),
+                            status,
+                        });
+                    }
+                }
+                Err(e) => {
+                    if attempt >= self.opts.retry_count {
+                        return Err(FetchError::Network {
+                            key: key.to_string(),
+                            url: url.to_string(),
+                            cause: e.to_string(),
+                        });
+                    }
+                }
+            }
+
+            // 指数バックオフ
+            let delay = self.opts.retry_base_delay_ms * (1u64 << attempt.min(6));
+            tokio::time::sleep(Duration::from_millis(delay)).await;
+            attempt += 1;
+        }
+    }
+
+    /// 複数アセットを並列ダウンロードする
+    ///
+    /// - `assets`: `(key, url, expected_hash)` のリスト
+    /// - `on_progress`: 各アセット完了時に呼ばれるコールバック（オプション）
+    /// - `token`: キャンセルシグナル
+    pub async fn fetch_all(
+        &self,
+        assets: Vec<(String, String, String)>,
+        on_progress: Option<Arc<dyn Fn(ProgressEvent) + Send + Sync>>,
+        token: CancellationToken,
+    ) -> Vec<Result<StrategyAsset, FetchError>> {
+        let total = assets.len();
+        let completed = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+
+        stream::iter(assets)
+            .map(|(key, url, hash)| {
+                let token = token.clone();
+                let progress = on_progress.clone();
+                let completed = completed.clone();
+                async move {
+                    let result = self.fetch_one(&key, &url, &hash, &token).await;
+                    match result {
+                        Ok(data) => {
+                            let n = completed.fetch_add(1, Ordering::Relaxed) + 1;
+                            if let Some(cb) = progress {
+                                cb(ProgressEvent {
+                                    key: key.clone(),
+                                    loaded_count: n,
+                                    total_count: total,
+                                });
+                            }
+                            Ok(StrategyAsset {
+                                key,
+                                url,
+                                hash,
+                                size: data.len() as u64,
+                                data,
+                            })
+                        }
+                        Err(e) => Err(e),
+                    }
+                }
+            })
+            .buffer_unordered(self.opts.concurrency)
+            .collect()
+            .await
+    }
+}
+
+// ─────────────────────────────────────────────
+// Tests
+// ─────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cancellation_token_works() {
+        let token = CancellationToken::new();
+        assert!(!token.is_cancelled());
+        token.cancel();
+        assert!(token.is_cancelled());
+    }
+
+    #[test]
+    fn fetch_options_defaults() {
+        let opts = FetchOptions::default();
+        assert_eq!(opts.concurrency, 4);
+        assert_eq!(opts.retry_count, 3);
+        assert!(opts.integrity_check);
+    }
+
+    #[test]
+    fn fetch_error_converts_to_load_error() {
+        let fe = FetchError::Integrity {
+            key: "a.js".to_string(),
+            expected: "abc".to_string(),
+            actual: "xyz".to_string(),
+        };
+        let le: LoadError = fe.into();
+        assert_eq!(le.kind, LoadErrorKind::Integrity);
+    }
+}

--- a/crates/s3d-loader/src/lib.rs
+++ b/crates/s3d-loader/src/lib.rs
@@ -1,0 +1,228 @@
+//! s3d-loader — CDN アセット配信戦略ローダー
+//!
+//! ## 概要
+//! `s3d-loader` はアセット配信戦略（`assetsStrategy`）に従い、
+//! 初期表示アセットの取得とバックグラウンド CDN 差分取得を行うクレートです。
+//!
+//! ## `strategy_assets()` フロー
+//!
+//! 1. **キャッシュ確認** — `initial.sources` がキャッシュにあればそのまま返す
+//! 2. **初期取得** — キャッシュミスの場合は CDN から取得し `cache=true` ならキャッシュ保存
+//! 3. **CDN 差分取得** — バックグラウンドで manifest をフェッチし差分アセットのみ取得
+//! 4. **リロード** — `reload.trigger` に従い manifest を再フェッチ → 変更があれば差分取得
+//!
+//! ## 制約
+//! - Service Worker 不使用
+//! - フレームワーク非依存（React/Vue 等への依存なし）
+//! - ブラウザ用 Wasm / CLI 用 native の両方でコンパイル可能
+
+pub mod cache;
+pub mod diff;
+pub mod fetcher;
+pub mod strategy;
+
+pub use cache::{AssetCache, CacheEntry};
+pub use diff::{diff_manifests, needs_evict, needs_fetch, DiffEntry};
+pub use fetcher::{CancellationToken, FetchError, FetchOptions, Fetcher, ProgressEvent};
+pub use strategy::{
+    AssetsStrategyConfig, CdnStrategyConfig, InitialConfig, ReloadConfig, ReloadStrategy,
+    ReloadTrigger, StrategyAsset,
+};
+
+use std::sync::Arc;
+
+use tokio::sync::Mutex;
+
+use s3d_types::manifest::DeployManifest;
+
+// ─────────────────────────────────────────────
+// AssetLoader — strategyAssets のエントリポイント
+// ─────────────────────────────────────────────
+
+/// `assetsStrategy` / `strategyAssets` のメインローダー
+///
+/// `Fetcher` と `AssetCache` を内包し、配信戦略に従いアセットを取得する。
+pub struct AssetLoader {
+    fetcher: Arc<Fetcher>,
+    cache: Arc<Mutex<AssetCache>>,
+    /// 最後にフェッチした manifest（リロード差分比較用）
+    last_manifest: Arc<Mutex<Option<DeployManifest>>>,
+}
+
+impl AssetLoader {
+    /// 新しい `AssetLoader` を作成する
+    pub fn new(opts: FetchOptions) -> Self {
+        Self {
+            fetcher: Arc::new(Fetcher::new(opts)),
+            cache: Arc::new(Mutex::new(AssetCache::new())),
+            last_manifest: Arc::new(Mutex::new(None)),
+        }
+    }
+
+    /// `assetsStrategy` フローに従い初期アセットを取得する
+    ///
+    /// ## フロー
+    /// 1. `manifest_url` から manifest をフェッチ
+    /// 2. `config.initial.sources` をキャッシュから確認（ヒットならスキップ）
+    /// 3. キャッシュミスのアセットを CDN から並列取得
+    /// 4. `config.initial.cache = true` ならキャッシュに保存
+    /// 5. 取得済みアセット一覧を返す
+    pub async fn strategy_assets(
+        &self,
+        manifest_url: &str,
+        config: &AssetsStrategyConfig,
+        on_progress: Option<Arc<dyn Fn(ProgressEvent) + Send + Sync>>,
+        token: CancellationToken,
+    ) -> Result<Vec<StrategyAsset>, FetchError> {
+        // 1. manifest 取得
+        let manifest = self.fetcher.fetch_manifest(manifest_url).await?;
+
+        // 2. initial.sources をキャッシュ確認 + 差分取得リスト構築
+        let mut to_fetch: Vec<(String, String, String)> = Vec::new();
+        let mut cached_assets: Vec<StrategyAsset> = Vec::new();
+
+        {
+            let cache = self.cache.lock().await;
+            for source_key in &config.initial.sources {
+                if let Some(entry) = manifest.assets.get(source_key) {
+                    if let Some(data) = cache.get(source_key, &entry.hash) {
+                        // キャッシュヒット
+                        cached_assets.push(StrategyAsset {
+                            key: source_key.clone(),
+                            url: entry.url.clone(),
+                            hash: entry.hash.clone(),
+                            size: entry.size,
+                            data: data.to_vec(),
+                        });
+                    } else {
+                        // キャッシュミス → 取得対象に追加
+                        to_fetch.push((source_key.clone(), entry.url.clone(), entry.hash.clone()));
+                    }
+                }
+            }
+        }
+
+        // 3. キャッシュミス分を並列取得
+        let fetched_results = if to_fetch.is_empty() {
+            vec![]
+        } else {
+            self.fetcher.fetch_all(to_fetch, on_progress, token).await
+        };
+
+        // エラーを収集（最初のエラーで早期リターン）
+        let mut fetched_assets: Vec<StrategyAsset> = Vec::new();
+        for result in fetched_results {
+            match result {
+                Ok(asset) => fetched_assets.push(asset),
+                Err(e) => return Err(e),
+            }
+        }
+
+        // 4. cache=true なら新規取得アセットをキャッシュ保存
+        if config.initial.cache {
+            let mut cache = self.cache.lock().await;
+            for asset in &fetched_assets {
+                cache.put(asset.key.clone(), asset.hash.clone(), asset.data.clone());
+            }
+        }
+
+        // 5. manifest をキャッシュして差分比較用に保存
+        *self.last_manifest.lock().await = Some(manifest);
+
+        // キャッシュヒット分 + 新規取得分を合わせて返す
+        let mut all = cached_assets;
+        all.extend(fetched_assets);
+        Ok(all)
+    }
+
+    /// バックグラウンド CDN 差分取得
+    ///
+    /// 新 manifest をフェッチし、変更のあったアセットだけを取得して
+    /// キャッシュを更新する。取得した差分アセット一覧を返す。
+    pub async fn fetch_cdn_diff(
+        &self,
+        manifest_url: &str,
+        on_progress: Option<Arc<dyn Fn(ProgressEvent) + Send + Sync>>,
+        token: CancellationToken,
+    ) -> Result<Vec<StrategyAsset>, FetchError> {
+        // 最新 manifest を強制再フェッチ
+        self.fetcher.invalidate_manifest_cache(manifest_url).await;
+        let new_manifest = self.fetcher.fetch_manifest(manifest_url).await?;
+
+        let old_manifest = self.last_manifest.lock().await.clone();
+
+        // diff 計算
+        let entries = diff_manifests(old_manifest.as_ref(), &new_manifest);
+        let to_fetch: Vec<(String, String, String)> = needs_fetch(&entries)
+            .into_iter()
+            .filter_map(|e| Some((e.key.clone(), e.url.clone()?, e.hash.clone()?)))
+            .collect();
+
+        // 古いキャッシュを削除
+        {
+            let mut cache = self.cache.lock().await;
+            for e in needs_evict(&entries) {
+                cache.evict(&e.key);
+            }
+        }
+
+        if to_fetch.is_empty() {
+            *self.last_manifest.lock().await = Some(new_manifest);
+            return Ok(vec![]);
+        }
+
+        let results = self.fetcher.fetch_all(to_fetch, on_progress, token).await;
+
+        let mut diff_assets: Vec<StrategyAsset> = Vec::new();
+        for result in results {
+            match result {
+                Ok(asset) => {
+                    // キャッシュ更新
+                    self.cache.lock().await.put(
+                        asset.key.clone(),
+                        asset.hash.clone(),
+                        asset.data.clone(),
+                    );
+                    diff_assets.push(asset);
+                }
+                Err(e) => return Err(e),
+            }
+        }
+
+        *self.last_manifest.lock().await = Some(new_manifest);
+        Ok(diff_assets)
+    }
+
+    /// 現在のキャッシュ内のアセット数を返す
+    pub async fn cached_count(&self) -> usize {
+        self.cache.lock().await.len()
+    }
+}
+
+// ─────────────────────────────────────────────
+// Tests
+// ─────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn asset_loader_creates_successfully() {
+        let _loader = AssetLoader::new(FetchOptions::default());
+    }
+
+    #[test]
+    fn cancellation_token_clone_shares_state() {
+        let token = CancellationToken::new();
+        let clone = token.clone();
+        token.cancel();
+        assert!(clone.is_cancelled());
+    }
+
+    #[tokio::test]
+    async fn cache_count_starts_at_zero() {
+        let loader = AssetLoader::new(FetchOptions::default());
+        assert_eq!(loader.cached_count().await, 0);
+    }
+}

--- a/crates/s3d-loader/src/strategy.rs
+++ b/crates/s3d-loader/src/strategy.rs
@@ -1,0 +1,171 @@
+//! 配信戦略の宣言型設定モジュール
+//!
+//! Issue #5 — `assetsStrategy` に対応する構造体群を定義する。
+//! CSS / JS / 画像 / フォント / JSON / HTML 断片など、
+//! あらゆる静的ファイルの配信戦略を宣言的に制御する。
+
+use serde::{Deserialize, Serialize};
+
+// ─────────────────────────────────────────────
+// ReloadTrigger / ReloadStrategy
+// ─────────────────────────────────────────────
+
+/// manifest 再取得のトリガー種別
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum ReloadTrigger {
+    /// manifest の変更を検知したとき
+    ManifestChange,
+    /// 一定間隔ごと
+    Interval,
+    /// 明示的な呼び出しのみ
+    Manual,
+}
+
+/// 再ロード時に差分だけ取得するか全取得するか
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum ReloadStrategy {
+    /// 差分アセットのみ取得
+    Diff,
+    /// 全アセットを再取得
+    Full,
+}
+
+// ─────────────────────────────────────────────
+// サブ設定構造体
+// ─────────────────────────────────────────────
+
+/// 初期表示アセットの設定
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct InitialConfig {
+    /// 初期表示に使うファイルパス一覧（manifest キー）
+    pub sources: Vec<String>,
+    /// ブラウザキャッシュ（Cache API）に保存するか
+    pub cache: bool,
+    /// キャッシュにもCDNにもない時の代替ファイルパス
+    pub fallback: Option<String>,
+}
+
+/// CDN 配信アセットの設定
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CdnStrategyConfig {
+    /// CDN 経由で非同期取得するファイルパターン（glob 形式）
+    pub files: Vec<String>,
+    /// CDN 取得後にキャッシュ有効化するか
+    pub cache: bool,
+    /// キャッシュ有効期間（例: `"1d"`, `"2h"`）
+    pub max_age: Option<String>,
+}
+
+/// 再ロードの設定
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ReloadConfig {
+    /// 再ロードトリガー（manifest-change / interval / manual）
+    pub trigger: ReloadTrigger,
+    /// 差分取得か全取得か
+    pub strategy: ReloadStrategy,
+    /// `Interval` トリガー時のポーリング間隔（ミリ秒）
+    pub interval_ms: Option<u64>,
+}
+
+// ─────────────────────────────────────────────
+// AssetsStrategyConfig — トップレベル
+// ─────────────────────────────────────────────
+
+/// アセット配信戦略の宣言型設定
+///
+/// TypeScript の `AssetsStrategyConfig` に対応する。
+/// ローダー初期化時に渡し、`strategy_assets()` で配信ポリシーを決定する。
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AssetsStrategyConfig {
+    /// 初期表示アセットの設定
+    pub initial: InitialConfig,
+    /// CDN 配信アセットの設定
+    pub cdn: CdnStrategyConfig,
+    /// 再ロードポリシー
+    pub reload: ReloadConfig,
+}
+
+// ─────────────────────────────────────────────
+// strategyAssets の結果型
+// ─────────────────────────────────────────────
+
+/// `strategy_assets()` が返す取得済みアセット情報
+#[derive(Debug, Clone)]
+pub struct StrategyAsset {
+    /// manifest キー（例: `"js/main.js"`）
+    pub key: String,
+    /// CDN URL
+    pub url: String,
+    /// SHA-256 ハッシュ（hex）
+    pub hash: String,
+    /// ファイルサイズ（バイト）
+    pub size: u64,
+    /// レスポンスボディ（bytes）
+    pub data: Vec<u8>,
+}
+
+// ─────────────────────────────────────────────
+// Tests
+// ─────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_config() -> AssetsStrategyConfig {
+        AssetsStrategyConfig {
+            initial: InitialConfig {
+                sources: vec!["js/main.js".to_string(), "style.css".to_string()],
+                cache: true,
+                fallback: Some("js/fallback.js".to_string()),
+            },
+            cdn: CdnStrategyConfig {
+                files: vec!["models/**/*.glb".to_string()],
+                cache: true,
+                max_age: Some("1d".to_string()),
+            },
+            reload: ReloadConfig {
+                trigger: ReloadTrigger::ManifestChange,
+                strategy: ReloadStrategy::Diff,
+                interval_ms: None,
+            },
+        }
+    }
+
+    #[test]
+    fn config_roundtrip_json() {
+        let cfg = sample_config();
+        let json = serde_json::to_string(&cfg).unwrap();
+        let back: AssetsStrategyConfig = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.initial.sources, cfg.initial.sources);
+        assert_eq!(back.cdn.max_age, Some("1d".to_string()));
+        assert_eq!(back.reload.trigger, ReloadTrigger::ManifestChange);
+        assert_eq!(back.reload.strategy, ReloadStrategy::Diff);
+    }
+
+    #[test]
+    fn reload_trigger_serde_kebab() {
+        let json = serde_json::to_string(&ReloadTrigger::ManifestChange).unwrap();
+        assert_eq!(json, r#""manifest-change""#);
+        let back: ReloadTrigger = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, ReloadTrigger::ManifestChange);
+    }
+
+    #[test]
+    fn reload_strategy_serde() {
+        assert_eq!(
+            serde_json::to_string(&ReloadStrategy::Diff).unwrap(),
+            r#""diff""#
+        );
+        assert_eq!(
+            serde_json::to_string(&ReloadStrategy::Full).unwrap(),
+            r#""full""#
+        );
+    }
+}

--- a/crates/s3d-loader/tests/loader_flow.rs
+++ b/crates/s3d-loader/tests/loader_flow.rs
@@ -1,0 +1,358 @@
+//! s3d-loader 統合テスト
+//!
+//! mockito を使ったモック HTTP サーバーで以下のフローをテストする:
+//!
+//! 1. `strategy_assets()` — initial 取得 → キャッシュ保存
+//! 2. キャッシュヒット — 2回目の `strategy_assets()` でキャッシュを使用
+//! 3. `fetch_cdn_diff()` — 新 manifest で変更のあったアセットだけを取得
+//! 4. 進捗コールバック — 3ファイル分のコールバックが呼ばれること
+
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+
+use sha2::{Digest, Sha256};
+
+use s3d_loader::{
+    AssetLoader, AssetsStrategyConfig, CancellationToken, CdnStrategyConfig, FetchOptions,
+    InitialConfig, ProgressEvent, ReloadConfig, ReloadStrategy, ReloadTrigger,
+};
+use s3d_types::manifest::{AssetEntry, DeployManifest};
+
+// ─────────────────────────────────────────────
+// ヘルパー
+// ─────────────────────────────────────────────
+
+fn sha256_hex(data: &[u8]) -> String {
+    let mut h = Sha256::new();
+    h.update(data);
+    hex::encode(h.finalize())
+}
+
+/// アセットデータの一覧からマニフェストを生成する
+/// キー: 元のキー（例: "js/main.js"）
+/// URL: base_url + "/" + hashed_key（例: "js/main.<hash8>.js"）
+fn make_manifest(base_url: &str, entries: &[(&str, &[u8])]) -> DeployManifest {
+    let mut assets = HashMap::new();
+    for (key, data) in entries {
+        let hash_full = sha256_hex(data);
+        let hash8 = &hash_full[..8];
+        let hashed_key = {
+            let dot = key.rfind('.').unwrap_or(key.len());
+            let (stem, ext) = key.split_at(dot);
+            format!("{}.{}{}", stem, hash8, ext)
+        };
+        assets.insert(
+            key.to_string(),
+            AssetEntry {
+                url: format!("{}/{}", base_url, hashed_key),
+                size: data.len() as u64,
+                hash: hash8.to_string(),
+                content_type: "application/javascript".to_string(),
+                dependencies: None,
+            },
+        );
+    }
+    DeployManifest {
+        schema_version: 1,
+        version: "1.0.0".to_string(),
+        build_time: "2026-03-20T00:00:00Z".to_string(),
+        assets,
+    }
+}
+
+fn default_config(sources: Vec<&str>) -> AssetsStrategyConfig {
+    AssetsStrategyConfig {
+        initial: InitialConfig {
+            sources: sources.into_iter().map(String::from).collect(),
+            cache: true,
+            fallback: None,
+        },
+        cdn: CdnStrategyConfig {
+            files: vec!["**/*.js".to_string()],
+            cache: true,
+            max_age: None,
+        },
+        reload: ReloadConfig {
+            trigger: ReloadTrigger::ManifestChange,
+            strategy: ReloadStrategy::Diff,
+            interval_ms: None,
+        },
+    }
+}
+
+// ─────────────────────────────────────────────
+// Test 1: initial 取得 → キャッシュ保存
+// ─────────────────────────────────────────────
+
+#[tokio::test]
+async fn test_strategy_assets_initial_fetch() {
+    let mut server = mockito::Server::new_async().await;
+    let base = server.url();
+
+    let data = b"console.log('hello')";
+    let files = [("js/main.js", data.as_ref())];
+    let manifest = make_manifest(&base, &files);
+
+    // hash8 を取得して hashed_key を再現
+    let hash_full = sha256_hex(data);
+    let hash8 = &hash_full[..8];
+    let hashed_key = format!("js/main.{}.js", hash8);
+
+    let manifest_json = serde_json::to_string(&manifest).unwrap();
+
+    let _m1 = server
+        .mock("GET", "/manifest.json")
+        .with_status(200)
+        .with_body(manifest_json)
+        .create_async()
+        .await;
+
+    let _m2 = server
+        .mock("GET", &format!("/{}", hashed_key) as &str)
+        .with_status(200)
+        .with_body(data)
+        .create_async()
+        .await;
+
+    let loader = AssetLoader::new(FetchOptions {
+        integrity_check: true,
+        ..Default::default()
+    });
+    let config = default_config(vec!["js/main.js"]);
+    let manifest_url = format!("{}/manifest.json", base);
+
+    let assets = loader
+        .strategy_assets(&manifest_url, &config, None, CancellationToken::new())
+        .await
+        .expect("strategy_assets should succeed");
+
+    assert_eq!(assets.len(), 1);
+    assert_eq!(assets[0].key, "js/main.js");
+    assert_eq!(assets[0].data, data.as_ref());
+    assert_eq!(loader.cached_count().await, 1);
+}
+
+// ─────────────────────────────────────────────
+// Test 2: キャッシュヒット（2回目はアセット HTTP 呼び出しなし）
+// ─────────────────────────────────────────────
+
+#[tokio::test]
+async fn test_strategy_assets_cache_hit() {
+    let mut server = mockito::Server::new_async().await;
+    let base = server.url();
+
+    let data = b"cached data";
+    let files = [("js/app.js", data.as_ref())];
+    let manifest = make_manifest(&base, &files);
+
+    let hash_full = sha256_hex(data);
+    let hash8 = &hash_full[..8];
+    let hashed_key = format!("js/app.{}.js", hash8);
+    let manifest_json = serde_json::to_string(&manifest).unwrap();
+
+    // manifest は2回以上呼ばれる（内部キャッシュが manifest 側にあるので1回のみだが許容）
+    let _m_manifest = server
+        .mock("GET", "/manifest.json")
+        .with_status(200)
+        .with_body(manifest_json)
+        .expect_at_least(1)
+        .create_async()
+        .await;
+
+    // アセットは1回だけ（2回目はキャッシュヒット）
+    let _m_asset = server
+        .mock("GET", &format!("/{}", hashed_key) as &str)
+        .with_status(200)
+        .with_body(data)
+        .expect(1)
+        .create_async()
+        .await;
+
+    let loader = AssetLoader::new(FetchOptions {
+        integrity_check: true,
+        ..Default::default()
+    });
+    let config = default_config(vec!["js/app.js"]);
+    let manifest_url = format!("{}/manifest.json", base);
+
+    // 1回目: ネットワーク取得
+    let assets1 = loader
+        .strategy_assets(&manifest_url, &config, None, CancellationToken::new())
+        .await
+        .expect("first call should succeed");
+    assert_eq!(assets1[0].data, data.as_ref());
+
+    // 2回目: キャッシュヒット
+    let assets2 = loader
+        .strategy_assets(&manifest_url, &config, None, CancellationToken::new())
+        .await
+        .expect("second call should succeed");
+    assert_eq!(assets2[0].data, data.as_ref());
+
+    // モックの expect(1) が満たされていることを assert
+    _m_asset.assert_async().await;
+}
+
+// ─────────────────────────────────────────────
+// Test 3: fetch_cdn_diff — 変更ファイルのみ取得
+// ─────────────────────────────────────────────
+
+#[tokio::test]
+async fn test_fetch_cdn_diff_only_modified() {
+    let mut server = mockito::Server::new_async().await;
+    let base = server.url();
+
+    let data_v1: &[u8] = b"version 1";
+    let data_v2: &[u8] = b"version 2 updated";
+    let data_static: &[u8] = b"static file unchanged";
+
+    // 旧 manifest（v1）
+    let old_manifest = make_manifest(
+        &base,
+        &[("js/main.js", data_v1), ("js/static.js", data_static)],
+    );
+    // 新 manifest（main.js が v2 に変更）
+    let new_manifest = make_manifest(
+        &base,
+        &[("js/main.js", data_v2), ("js/static.js", data_static)],
+    );
+
+    let old_json = serde_json::to_string(&old_manifest).unwrap();
+    let new_json = serde_json::to_string(&new_manifest).unwrap();
+
+    // manifest: 1回目は旧、2回目以降は新
+    let _m_old = server
+        .mock("GET", "/manifest.json")
+        .with_status(200)
+        .with_body(old_json)
+        .expect(1)
+        .create_async()
+        .await;
+    let _m_new = server
+        .mock("GET", "/manifest.json")
+        .with_status(200)
+        .with_body(new_json)
+        .create_async()
+        .await;
+
+    // アセット v1
+    let hash_v1 = sha256_hex(data_v1);
+    let hk_v1 = format!("js/main.{}.js", &hash_v1[..8]);
+    let _m_v1 = server
+        .mock("GET", &format!("/{}", hk_v1) as &str)
+        .with_status(200)
+        .with_body(data_v1)
+        .create_async()
+        .await;
+
+    // アセット static
+    let hash_static = sha256_hex(data_static);
+    let hk_static = format!("js/static.{}.js", &hash_static[..8]);
+    let _m_static = server
+        .mock("GET", &format!("/{}", hk_static) as &str)
+        .with_status(200)
+        .with_body(data_static)
+        .create_async()
+        .await;
+
+    // アセット v2
+    let hash_v2 = sha256_hex(data_v2);
+    let hk_v2 = format!("js/main.{}.js", &hash_v2[..8]);
+    let _m_v2 = server
+        .mock("GET", &format!("/{}", hk_v2) as &str)
+        .with_status(200)
+        .with_body(data_v2)
+        .create_async()
+        .await;
+
+    let loader = AssetLoader::new(FetchOptions {
+        integrity_check: true,
+        ..Default::default()
+    });
+    let config = default_config(vec!["js/main.js", "js/static.js"]);
+    let manifest_url = format!("{}/manifest.json", base);
+
+    // 初回ロード（旧 manifest）
+    let initial = loader
+        .strategy_assets(&manifest_url, &config, None, CancellationToken::new())
+        .await
+        .expect("initial load should succeed");
+    assert_eq!(initial.len(), 2);
+
+    // 差分取得（新 manifest: js/main.js のみ変更）
+    let diff_assets = loader
+        .fetch_cdn_diff(&manifest_url, None, CancellationToken::new())
+        .await
+        .expect("cdn diff should succeed");
+
+    assert_eq!(diff_assets.len(), 1);
+    assert_eq!(diff_assets[0].key, "js/main.js");
+    assert_eq!(diff_assets[0].data, data_v2.as_ref());
+}
+
+// ─────────────────────────────────────────────
+// Test 4: 進捗コールバック
+// ─────────────────────────────────────────────
+
+#[tokio::test]
+async fn test_progress_callback_called() {
+    let mut server = mockito::Server::new_async().await;
+    let base = server.url();
+
+    let files: Vec<(&str, &[u8])> = vec![
+        ("js/a.js", b"aaa"),
+        ("js/b.js", b"bbb"),
+        ("js/c.js", b"ccc"),
+    ];
+
+    let manifest = make_manifest(&base, &files);
+    let manifest_json = serde_json::to_string(&manifest).unwrap();
+
+    let _m_manifest = server
+        .mock("GET", "/manifest.json")
+        .with_status(200)
+        .with_body(manifest_json)
+        .create_async()
+        .await;
+
+    for (key, data) in &files {
+        let hash_full = sha256_hex(data);
+        let hash8 = &hash_full[..8];
+        let dot = key.rfind('.').unwrap_or(key.len());
+        let (stem, ext) = key.split_at(dot);
+        let hashed_key = format!("{}.{}{}", stem, hash8, ext);
+        server
+            .mock("GET", &format!("/{}", hashed_key) as &str)
+            .with_status(200)
+            .with_body(*data)
+            .create_async()
+            .await;
+    }
+
+    let progress_count = Arc::new(AtomicUsize::new(0));
+    let pc = progress_count.clone();
+    let on_progress: Arc<dyn Fn(ProgressEvent) + Send + Sync> =
+        Arc::new(move |_: ProgressEvent| {
+            pc.fetch_add(1, Ordering::SeqCst);
+        });
+
+    let loader = AssetLoader::new(FetchOptions {
+        integrity_check: true,
+        ..Default::default()
+    });
+    let config = default_config(vec!["js/a.js", "js/b.js", "js/c.js"]);
+    let manifest_url = format!("{}/manifest.json", base);
+
+    loader
+        .strategy_assets(
+            &manifest_url,
+            &config,
+            Some(on_progress),
+            CancellationToken::new(),
+        )
+        .await
+        .expect("should succeed");
+
+    assert_eq!(progress_count.load(Ordering::SeqCst), 3);
+}


### PR DESCRIPTION
## 概要

Issue #5 の実装として `crates/s3d-loader` クレートを追加します。
CDN アセット配信戦略の宣言（`assetsStrategy`）と取得（`strategyAssets`）を実装しています。

## 新規ファイル

| ファイル | 説明 |
|---|---|
| `Cargo.toml` | s3d-types / sha2 / reqwest / tokio / futures / serde / thiserror |
| `src/strategy.rs` | `AssetsStrategyConfig` / `InitialConfig` / `CdnStrategyConfig` / `ReloadConfig` / `StrategyAsset` |
| `src/cache.rs` | `AssetCache` — ハッシュキーベースのインメモリキャッシュ（Service Worker 不使用） |
| `src/fetcher.rs` | `Fetcher` — 並列 DL・SHA-256 整合性チェック・リトライ・進捗コールバック・`CancellationToken` |
| `src/diff.rs` | `diff_manifests()` — manifest 差分検知（Added / Modified / Deleted / Unchanged） |
| `src/lib.rs` | `AssetLoader` — `strategy_assets()` + `fetch_cdn_diff()` |
| `tests/loader_flow.rs` | 統合テスト（mockito）|

## strategyAssets フロー

```
strategy_assets(manifest_url, config)
  ├── fetch_manifest(manifest_url)
  ├── initial.sources をキャッシュ確認
  │   ├── ヒット → キャッシュから返す
  │   └── ミス  → CDN から並列取得 → cache=true ならキャッシュ保存
  └── → Vec<StrategyAsset> を返す

fetch_cdn_diff(manifest_url)
  ├── manifest 再フェッチ（キャッシュ無効化）
  ├── diff_manifests(old, new)
  ├── needs_evict → キャッシュから削除
  ├── needs_fetch → CDN から並列取得
  └── → 差分 Vec<StrategyAsset> を返す
```

## テスト内容（統合テスト × 4）

| テスト | 内容 |
|---|---|
| `test_strategy_assets_initial_fetch` | 初回取得・キャッシュ保存確認 |
| `test_strategy_assets_cache_hit` | 2回目はアセット HTTP 呼び出しなし |
| `test_fetch_cdn_diff_only_modified` | 変更1件のみ取得（static は除外） |
| `test_progress_callback_called` | 3ファイル分のコールバック |

## テスト結果

```
unit:        21 passed
integration:  4 passed
total:       25 passed; 0 failed
```

Closes #5