### PR TITLE
feat(s3d-display): add s3d-display crate — HTML generation & iframe normalization — Closes #8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1096,6 +1096,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "s3d-display"
+version = "0.1.0"
+dependencies = [
+ "s3d-loader",
+ "s3d-types",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "s3d-loader"
 version = "0.1.0"
 dependencies = [

--- a/crates/s3d-display/Cargo.toml
+++ b/crates/s3d-display/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "s3d-display"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+s3d-types = { path = "../s3d-types" }
+s3d-loader = { path = "../s3d-loader" }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+thiserror = "1"
+
+[dev-dependencies]
+tempfile = "3"

--- a/crates/s3d-display/src/config.rs
+++ b/crates/s3d-display/src/config.rs
@@ -1,0 +1,253 @@
+//! display 側の設定読み込み・バリデーションモジュール
+//!
+//! `DisplayProjectConfig` は `s3d-display.json` または
+//! `s3d.config.json` の `display` セクションから読み込む。
+//! `s3d-loader` の `AssetsStrategyConfig` を再利用し、
+//! iframe 分割ルールも同じファイルに宣言する。
+
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+use s3d_loader::AssetsStrategyConfig;
+
+// ─────────────────────────────────────────────
+// エラー型
+// ─────────────────────────────────────────────
+
+/// config モジュールのエラー型
+#[derive(Debug, Error)]
+pub enum ConfigError {
+    #[error("I/O error reading config `{path}`: {source}")]
+    Io {
+        path: String,
+        #[source]
+        source: std::io::Error,
+    },
+
+    #[error("JSON parse error in `{path}`: {source}")]
+    Parse {
+        path: String,
+        #[source]
+        source: serde_json::Error,
+    },
+
+    #[error("Validation error: {0}")]
+    Validation(String),
+}
+
+// ─────────────────────────────────────────────
+// IframePartRule — 分割ルール1件
+// ─────────────────────────────────────────────
+
+/// 1パーツの分割ルール
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct IframePartRule {
+    /// パーツ ID（マーカーコメント `<!-- s3d-part: <id> -->` と対応）
+    pub id: String,
+    /// 出力先相対パス（例: `"parts/header.html"`）
+    pub output_path: String,
+    /// Cache-Control ヘッダー値（省略可）
+    pub cache_control: Option<String>,
+}
+
+// ─────────────────────────────────────────────
+// IframeConfig — iframe 正規化の設定
+// ─────────────────────────────────────────────
+
+/// iframe 正規化の設定
+///
+/// `partition_rules` が空の場合、分割は行わずページ全体を単一 HTML として出力する。
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct IframeConfig {
+    /// 分割ルール一覧
+    pub partition_rules: Vec<IframePartRule>,
+    /// 親ページでのデフォルト iframe 属性（例: `"width=100% frameborder=0"`）
+    pub iframe_attrs: Option<String>,
+}
+
+// ─────────────────────────────────────────────
+// DisplayProjectConfig — トップレベル設定
+// ─────────────────────────────────────────────
+
+/// s3d-display プロジェクト設定
+///
+/// `s3d-display.json` または `s3d.config.json` の `display` セクションに対応する。
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DisplayProjectConfig {
+    /// HTML 出力先ディレクトリ（例: `"output"`）
+    pub output_dir: String,
+    /// CDN manifest の URL（例: `"https://cdn.example.com/manifest.json"`）
+    pub manifest_url: String,
+    /// アセット配信戦略（s3d-loader の AssetsStrategyConfig を再利用）
+    pub assets_strategy: AssetsStrategyConfig,
+    /// iframe 分割設定
+    #[serde(default)]
+    pub iframe: IframeConfig,
+    /// ページタイトル（省略時は `"s3d app"`）
+    pub title: Option<String>,
+    /// 追加で `<head>` に挿入する HTML スニペット（省略可）
+    pub extra_head: Option<String>,
+}
+
+// ─────────────────────────────────────────────
+// 読み込み・バリデーション
+// ─────────────────────────────────────────────
+
+impl DisplayProjectConfig {
+    /// JSON ファイルから設定を読み込む
+    pub fn from_file(path: &str) -> Result<Self, ConfigError> {
+        let content = std::fs::read_to_string(path).map_err(|source| ConfigError::Io {
+            path: path.to_string(),
+            source,
+        })?;
+        Self::from_json(&content, path)
+    }
+
+    /// JSON 文字列から設定をパースする
+    pub fn from_json(json: &str, source_path: &str) -> Result<Self, ConfigError> {
+        let cfg: Self = serde_json::from_str(json).map_err(|source| ConfigError::Parse {
+            path: source_path.to_string(),
+            source,
+        })?;
+        cfg.validate()?;
+        Ok(cfg)
+    }
+
+    /// バリデーション
+    pub fn validate(&self) -> Result<(), ConfigError> {
+        if self.output_dir.is_empty() {
+            return Err(ConfigError::Validation(
+                "outputDir must not be empty".to_string(),
+            ));
+        }
+        if self.manifest_url.is_empty() {
+            return Err(ConfigError::Validation(
+                "manifestUrl must not be empty".to_string(),
+            ));
+        }
+        // partition_rules の id 重複チェック
+        let mut ids = std::collections::HashSet::new();
+        for rule in &self.iframe.partition_rules {
+            if rule.id.is_empty() {
+                return Err(ConfigError::Validation(
+                    "partition rule id must not be empty".to_string(),
+                ));
+            }
+            if !ids.insert(rule.id.clone()) {
+                return Err(ConfigError::Validation(format!(
+                    "duplicate partition rule id: `{}`",
+                    rule.id
+                )));
+            }
+        }
+        Ok(())
+    }
+
+    /// ページタイトルを返す（デフォルト: `"s3d app"`）
+    pub fn title(&self) -> &str {
+        self.title.as_deref().unwrap_or("s3d app")
+    }
+}
+
+// ─────────────────────────────────────────────
+// Tests
+// ─────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use s3d_loader::{
+        CdnStrategyConfig, InitialConfig, ReloadConfig, ReloadStrategy, ReloadTrigger,
+    };
+
+    fn sample_json() -> String {
+        serde_json::json!({
+            "outputDir": "output",
+            "manifestUrl": "https://cdn.example.com/manifest.json",
+            "assetsStrategy": {
+                "initial": {
+                    "sources": ["js/main.js", "style.css"],
+                    "cache": true
+                },
+                "cdn": {
+                    "files": ["models/**/*.glb"],
+                    "cache": true
+                },
+                "reload": {
+                    "trigger": "manifest-change",
+                    "strategy": "diff"
+                }
+            },
+            "iframe": {
+                "partitionRules": [
+                    { "id": "header", "outputPath": "parts/header.html", "cacheControl": "max-age=3600" },
+                    { "id": "main",   "outputPath": "parts/main.html" },
+                    { "id": "footer", "outputPath": "parts/footer.html" }
+                ]
+            },
+            "title": "My 3D App"
+        })
+        .to_string()
+    }
+
+    #[test]
+    fn parse_full_config() {
+        let cfg = DisplayProjectConfig::from_json(&sample_json(), "test.json").unwrap();
+        assert_eq!(cfg.output_dir, "output");
+        assert_eq!(cfg.manifest_url, "https://cdn.example.com/manifest.json");
+        assert_eq!(cfg.title(), "My 3D App");
+        assert_eq!(cfg.iframe.partition_rules.len(), 3);
+        assert_eq!(cfg.iframe.partition_rules[0].id, "header");
+        assert_eq!(
+            cfg.iframe.partition_rules[0].cache_control,
+            Some("max-age=3600".to_string())
+        );
+        assert!(cfg.iframe.partition_rules[1].cache_control.is_none());
+    }
+
+    #[test]
+    fn default_title() {
+        let mut json: serde_json::Value = serde_json::from_str(&sample_json()).unwrap();
+        json.as_object_mut().unwrap().remove("title");
+        let cfg = DisplayProjectConfig::from_json(&json.to_string(), "test.json").unwrap();
+        assert_eq!(cfg.title(), "s3d app");
+    }
+
+    #[test]
+    fn validation_empty_output_dir() {
+        let mut json: serde_json::Value = serde_json::from_str(&sample_json()).unwrap();
+        json["outputDir"] = serde_json::json!("");
+        let result = DisplayProjectConfig::from_json(&json.to_string(), "test.json");
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("outputDir"));
+    }
+
+    #[test]
+    fn validation_duplicate_part_id() {
+        let mut json: serde_json::Value = serde_json::from_str(&sample_json()).unwrap();
+        json["iframe"]["partitionRules"] = serde_json::json!([
+            { "id": "header", "outputPath": "parts/header.html" },
+            { "id": "header", "outputPath": "parts/header2.html" }
+        ]);
+        let result = DisplayProjectConfig::from_json(&json.to_string(), "test.json");
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("duplicate"));
+    }
+
+    #[test]
+    fn assets_strategy_roundtrip() {
+        let cfg = DisplayProjectConfig::from_json(&sample_json(), "test.json").unwrap();
+        assert_eq!(
+            cfg.assets_strategy.initial.sources,
+            vec!["js/main.js", "style.css"]
+        );
+        assert_eq!(
+            cfg.assets_strategy.reload.trigger,
+            ReloadTrigger::ManifestChange
+        );
+        assert_eq!(cfg.assets_strategy.reload.strategy, ReloadStrategy::Diff);
+    }
+}

--- a/crates/s3d-display/src/iframe.rs
+++ b/crates/s3d-display/src/iframe.rs
@@ -1,0 +1,274 @@
+//! iframe 正規化モジュール
+//!
+//! HTML を `<!-- s3d-part: <id> -->` コメントマーカーでパーツに分割し、
+//! 各パーツを独立 HTML ファイルとして出力する。
+//! 親ページは `<iframe src="parts/<id>.html">` でパーツを参照する。
+//!
+//! ## マーカー書式
+//!
+//! ```html
+//! <!-- s3d-part: header -->
+//! <header>...</header>
+//! <!-- s3d-part-end -->
+//! ```
+//!
+//! - 開始マーカー: `<!-- s3d-part: <id> -->`
+//! - 終了マーカー: `<!-- s3d-part-end -->`
+//! - マーカー間のコンテンツがパーツ HTML のボディになる
+
+use crate::config::IframePartRule;
+
+// ─────────────────────────────────────────────
+// Part — 分割されたパーツ1件
+// ─────────────────────────────────────────────
+
+/// HTML 分割後の1パーツ
+#[derive(Debug, Clone, PartialEq)]
+pub struct Part {
+    /// パーツ ID（マーカーの `<id>` 部分）
+    pub id: String,
+    /// パーツ本体の HTML コンテンツ（`<body>` 内側のみ）
+    pub content: String,
+    /// 設定から解決した出力先パス（例: `"parts/header.html"`）
+    pub output_path: String,
+    /// Cache-Control ヘッダー値
+    pub cache_control: Option<String>,
+}
+
+// ─────────────────────────────────────────────
+// IframePartition — 分割結果
+// ─────────────────────────────────────────────
+
+/// `partition_page()` の返却値
+#[derive(Debug, Clone)]
+pub struct IframePartition {
+    /// 元の HTML からパーツを除いた「親ページ本体」の内容
+    /// （マーカーが `<iframe>` タグに置換済み）
+    pub parent_content: String,
+    /// 分割されたパーツ一覧
+    pub parts: Vec<Part>,
+}
+
+// ─────────────────────────────────────────────
+// partition_page
+// ─────────────────────────────────────────────
+
+/// HTML 文字列をパーツに分割する
+///
+/// - `html`: 元の HTML 文字列
+/// - `rules`: `IframePartRule` のスライス（ID → output_path / cache_control のマッピング）
+/// - `iframe_attrs`: `<iframe>` タグに追加する属性文字列（省略可）
+///
+/// マーカーが見つからない場合は `parts` が空の `IframePartition` を返す。
+pub fn partition_page(
+    html: &str,
+    rules: &[IframePartRule],
+    iframe_attrs: Option<&str>,
+) -> IframePartition {
+    let attrs = iframe_attrs.unwrap_or("width=\"100%\" frameborder=\"0\"");
+    let mut parent = String::with_capacity(html.len());
+    let mut parts: Vec<Part> = Vec::new();
+
+    let mut remaining = html;
+
+    while !remaining.is_empty() {
+        // 開始マーカーを探す: `<!-- s3d-part: <id> -->`
+        if let Some(start_pos) = find_part_start(remaining) {
+            // マーカー前の部分を親ページに追加
+            parent.push_str(&remaining[..start_pos.marker_start]);
+
+            let part_id = start_pos.part_id.clone();
+
+            // 終了マーカーを探す
+            let after_start = &remaining[start_pos.marker_end..];
+            if let Some(end_pos) = find_part_end(after_start) {
+                let content = after_start[..end_pos.marker_start].trim().to_string();
+
+                // output_path と cache_control をルールから解決
+                let (output_path, cache_control) = resolve_rule(rules, &part_id);
+
+                // `<iframe>` タグで置換（src は output_path の basename）
+                let iframe_src = output_path.clone();
+                parent.push_str(&format!(
+                    "<iframe src=\"{}\" {}></iframe>",
+                    iframe_src, attrs
+                ));
+
+                parts.push(Part {
+                    id: part_id,
+                    content,
+                    output_path,
+                    cache_control,
+                });
+
+                remaining = &remaining[start_pos.marker_end + end_pos.marker_end..];
+            } else {
+                // 終了マーカーなし → 残りをそのまま親ページに追加して終了
+                parent.push_str(&remaining[start_pos.marker_start..]);
+                remaining = "";
+            }
+        } else {
+            // これ以上マーカーなし → 残りをすべて親ページに追加
+            parent.push_str(remaining);
+            remaining = "";
+        }
+    }
+
+    IframePartition {
+        parent_content: parent,
+        parts,
+    }
+}
+
+// ─────────────────────────────────────────────
+// 内部ヘルパー
+// ─────────────────────────────────────────────
+
+struct MarkerPos {
+    /// HTML 内でのマーカー開始位置
+    marker_start: usize,
+    /// マーカー終了位置（次の解析開始位置）
+    marker_end: usize,
+    /// パーツ ID
+    part_id: String,
+}
+
+/// `<!-- s3d-part: <id> -->` を探して位置と ID を返す
+fn find_part_start(html: &str) -> Option<MarkerPos> {
+    const PREFIX: &str = "<!-- s3d-part:";
+    const SUFFIX: &str = "-->";
+
+    let start = html.find(PREFIX)?;
+    let after_prefix = &html[start + PREFIX.len()..];
+    let end_rel = after_prefix.find(SUFFIX)?;
+    let part_id = after_prefix[..end_rel].trim().to_string();
+    let marker_end = start + PREFIX.len() + end_rel + SUFFIX.len();
+
+    Some(MarkerPos {
+        marker_start: start,
+        marker_end,
+        part_id,
+    })
+}
+
+/// `<!-- s3d-part-end -->` を探して位置を返す
+fn find_part_end(html: &str) -> Option<MarkerPos> {
+    const MARKER: &str = "<!-- s3d-part-end -->";
+    let start = html.find(MARKER)?;
+    Some(MarkerPos {
+        marker_start: start,
+        marker_end: start + MARKER.len(),
+        part_id: String::new(),
+    })
+}
+
+/// ルール一覧から ID に対応する `(output_path, cache_control)` を返す
+/// ルールが見つからない場合はデフォルトのパスを生成する
+fn resolve_rule(rules: &[IframePartRule], id: &str) -> (String, Option<String>) {
+    if let Some(rule) = rules.iter().find(|r| r.id == id) {
+        (rule.output_path.clone(), rule.cache_control.clone())
+    } else {
+        // ルールが未定義の場合はデフォルトパスを生成
+        (format!("parts/{}.html", id), None)
+    }
+}
+
+// ─────────────────────────────────────────────
+// Tests
+// ─────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::IframePartRule;
+
+    fn rules() -> Vec<IframePartRule> {
+        vec![
+            IframePartRule {
+                id: "header".to_string(),
+                output_path: "parts/header.html".to_string(),
+                cache_control: Some("max-age=3600".to_string()),
+            },
+            IframePartRule {
+                id: "main".to_string(),
+                output_path: "parts/main.html".to_string(),
+                cache_control: None,
+            },
+            IframePartRule {
+                id: "footer".to_string(),
+                output_path: "parts/footer.html".to_string(),
+                cache_control: Some("max-age=86400".to_string()),
+            },
+        ]
+    }
+
+    #[test]
+    fn partition_three_parts() {
+        let html = r#"<!DOCTYPE html>
+<html>
+<body>
+<!-- s3d-part: header -->
+<header><h1>Title</h1></header>
+<!-- s3d-part-end -->
+<main>
+<!-- s3d-part: main -->
+<p>Content</p>
+<!-- s3d-part-end -->
+</main>
+<!-- s3d-part: footer -->
+<footer>Footer</footer>
+<!-- s3d-part-end -->
+</body>
+</html>"#;
+
+        let result = partition_page(html, &rules(), None);
+        assert_eq!(result.parts.len(), 3);
+
+        let header = result.parts.iter().find(|p| p.id == "header").unwrap();
+        assert!(header.content.contains("<header>"));
+        assert_eq!(header.output_path, "parts/header.html");
+        assert_eq!(header.cache_control, Some("max-age=3600".to_string()));
+
+        let main = result.parts.iter().find(|p| p.id == "main").unwrap();
+        assert!(main.content.contains("<p>Content</p>"));
+        assert!(main.cache_control.is_none());
+
+        // 親ページには <iframe> タグが含まれる
+        assert!(result.parent_content.contains("<iframe"));
+        assert!(result.parent_content.contains("parts/header.html"));
+        assert!(result.parent_content.contains("parts/main.html"));
+        assert!(result.parent_content.contains("parts/footer.html"));
+        // 元のパーツコンテンツは残っていない
+        assert!(!result.parent_content.contains("<header>"));
+    }
+
+    #[test]
+    fn no_markers_returns_full_html() {
+        let html = "<html><body><p>No markers</p></body></html>";
+        let result = partition_page(html, &rules(), None);
+        assert_eq!(result.parts.len(), 0);
+        assert_eq!(result.parent_content, html);
+    }
+
+    #[test]
+    fn unknown_part_id_uses_default_path() {
+        let html = "<!-- s3d-part: unknown --><div>x</div><!-- s3d-part-end -->";
+        let result = partition_page(html, &[], None);
+        assert_eq!(result.parts.len(), 1);
+        assert_eq!(result.parts[0].output_path, "parts/unknown.html");
+    }
+
+    #[test]
+    fn iframe_attrs_applied() {
+        let html = "<!-- s3d-part: header --><h1>H</h1><!-- s3d-part-end -->";
+        let result = partition_page(html, &rules(), Some("loading=\"lazy\""));
+        assert!(result.parent_content.contains("loading=\"lazy\""));
+    }
+
+    #[test]
+    fn part_content_is_trimmed() {
+        let html = "<!-- s3d-part: main -->\n  <p>hi</p>\n<!-- s3d-part-end -->";
+        let result = partition_page(html, &rules(), None);
+        assert_eq!(result.parts[0].content, "<p>hi</p>");
+    }
+}

--- a/crates/s3d-display/src/lib.rs
+++ b/crates/s3d-display/src/lib.rs
@@ -1,0 +1,209 @@
+//! s3d-display — HTML 生成インターフェースと iframe 正規化
+//!
+//! ## 概要
+//! `s3d-display` はフロント開発者向けの display 層クレートです。
+//! `assetsStrategy` の宣言、`strategyAssets` の呼び出し、
+//! iframe 正規化による HTML パーツ分割を提供します。
+//!
+//! ## モジュール構成
+//!
+//! | モジュール | 役割 |
+//! |---|---|
+//! | `config`   | `DisplayProjectConfig` の読み込み・バリデーション |
+//! | `iframe`   | `<!-- s3d-part: id -->` マーカーによる HTML 分割 |
+//! | `template` | 親ページ・パーツ HTML テンプレート生成 |
+//! | `output`   | 出力ディレクトリへのファイル書き出し |
+//! | `plugin`   | `PlainHtmlDisplay` — `DisplayPlugin` のデフォルト実装 |
+//!
+//! ## 使い方
+//!
+//! ```no_run
+//! use s3d_display::{DisplayProjectConfig, PlainHtmlDisplay};
+//! use s3d_types::plugin::{DisplayPlugin, RenderContext};
+//!
+//! // 設定を読み込む
+//! let config = DisplayProjectConfig::from_file("s3d-display.json").unwrap();
+//!
+//! // プラグインを作成
+//! let plugin = PlainHtmlDisplay::new(config);
+//!
+//! // HTML 生成（RenderContext は s3d-types で定義）
+//! // let outputs = plugin.render(&context);
+//! // s3d_display::write_outputs("output/", &outputs).unwrap();
+//! ```
+
+pub mod config;
+pub mod iframe;
+pub mod output;
+pub mod plugin;
+pub mod template;
+
+// 主要な型を再エクスポート
+pub use config::{ConfigError, DisplayProjectConfig, IframeConfig, IframePartRule};
+pub use iframe::{partition_page, IframePartition, Part};
+pub use output::{collect_output_files, write_output_files, OutputError, OutputFile};
+pub use plugin::PlainHtmlDisplay;
+pub use template::{render_parent_page, render_part_page, TemplateOptions};
+
+use std::path::Path;
+
+use s3d_types::plugin::HtmlOutput;
+
+// ─────────────────────────────────────────────
+// ビルドエントリポイント
+// ─────────────────────────────────────────────
+
+/// `DisplayPlugin::render()` の結果を出力ディレクトリに書き出す便利関数
+///
+/// `HtmlOutput` の `path` は `output_dir` からの相対パスとして扱う。
+pub fn write_outputs(output_dir: &str, outputs: &[HtmlOutput]) -> Result<(), OutputError> {
+    let dir = Path::new(output_dir);
+    let files: Vec<OutputFile> = outputs
+        .iter()
+        .map(|o| OutputFile {
+            relative_path: o.path.clone(),
+            content: o.content.clone(),
+            cache_control: o.cache_control.clone(),
+        })
+        .collect();
+    write_output_files(dir, &files).map(|_| ())
+}
+
+// ─────────────────────────────────────────────
+// Tests
+// ─────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+    use tempfile::TempDir;
+
+    use s3d_loader::{
+        AssetsStrategyConfig, CdnStrategyConfig, InitialConfig, ReloadConfig, ReloadStrategy,
+        ReloadTrigger,
+    };
+    use s3d_types::config::{DisplayConfig, LoaderDisplayConfig, S3dConfig};
+    use s3d_types::manifest::{AssetEntry, DeployManifest};
+    use s3d_types::plugin::{DisplayPlugin, RenderContext};
+
+    fn sample_strategy() -> AssetsStrategyConfig {
+        AssetsStrategyConfig {
+            initial: InitialConfig {
+                sources: vec!["js/main.js".to_string()],
+                cache: true,
+                fallback: None,
+            },
+            cdn: CdnStrategyConfig {
+                files: vec!["models/**".to_string()],
+                cache: true,
+                max_age: None,
+            },
+            reload: ReloadConfig {
+                trigger: ReloadTrigger::ManifestChange,
+                strategy: ReloadStrategy::Diff,
+                interval_ms: None,
+            },
+        }
+    }
+
+    fn sample_manifest() -> DeployManifest {
+        let mut assets = HashMap::new();
+        assets.insert(
+            "js/app.js".to_string(),
+            AssetEntry {
+                url: "https://cdn.example.com/js/app.abc.js".to_string(),
+                size: 512,
+                hash: "abc123".to_string(),
+                content_type: "application/javascript".to_string(),
+                dependencies: None,
+            },
+        );
+        DeployManifest {
+            schema_version: 1,
+            version: "2.0.0".to_string(),
+            build_time: "2026-03-20T00:00:00Z".to_string(),
+            assets,
+        }
+    }
+
+    fn sample_s3d_config() -> S3dConfig {
+        S3dConfig {
+            schema_version: 1,
+            project: "s3d-test".to_string(),
+            deploy: None,
+            display: Some(DisplayConfig {
+                loader: LoaderDisplayConfig {
+                    concurrency: None,
+                    retry_count: None,
+                    retry_base_delay: None,
+                    timeout: None,
+                },
+            }),
+            draft: None,
+        }
+    }
+
+    #[test]
+    fn write_outputs_creates_files() {
+        let tmp = TempDir::new().unwrap();
+        let outputs = vec![
+            HtmlOutput {
+                path: "index.html".to_string(),
+                content: "<html>parent</html>".to_string(),
+                cache_control: None,
+            },
+            HtmlOutput {
+                path: "parts/header.html".to_string(),
+                content: "<html>header</html>".to_string(),
+                cache_control: Some("max-age=3600".to_string()),
+            },
+        ];
+
+        write_outputs(tmp.path().to_str().unwrap(), &outputs).unwrap();
+        assert!(tmp.path().join("index.html").exists());
+        assert!(tmp.path().join("parts/header.html").exists());
+    }
+
+    #[test]
+    fn end_to_end_plain_html_display() {
+        let config_json = serde_json::json!({
+            "outputDir": "output",
+            "manifestUrl": "https://cdn.example.com/manifest.json",
+            "assetsStrategy": {
+                "initial": {
+                    "sources": ["js/main.js"],
+                    "cache": true
+                },
+                "cdn": {
+                    "files": ["models/**"],
+                    "cache": true
+                },
+                "reload": {
+                    "trigger": "manifest-change",
+                    "strategy": "diff"
+                }
+            },
+            "title": "E2E Test App"
+        })
+        .to_string();
+
+        let cfg = DisplayProjectConfig::from_json(&config_json, "test.json").unwrap();
+        let plugin = PlainHtmlDisplay::new(cfg);
+        let s3d_config = sample_s3d_config();
+        let manifest = sample_manifest();
+        let context = RenderContext {
+            config: &s3d_config,
+            manifest: &manifest,
+        };
+
+        let outputs = plugin.render(&context);
+        assert!(!outputs.is_empty());
+
+        let index = &outputs[0];
+        assert_eq!(index.path, "index.html");
+        assert!(index.content.contains("E2E Test App"));
+        assert!(index.content.contains("manifest-change"));
+        assert!(index.content.contains("js/app.js")); // manifest キーがボディに含まれる
+    }
+}

--- a/crates/s3d-display/src/output.rs
+++ b/crates/s3d-display/src/output.rs
@@ -1,0 +1,204 @@
+//! 出力ディレクトリへの書き出しモジュール
+//!
+//! 生成した HTML ファイル群を指定ディレクトリに書き出す。
+//!
+//! ## ディレクトリ構造
+//! ```text
+//! output/
+//! ├─ index.html          ← 親ページ
+//! ├─ parts/
+//! │   ├─ header.html
+//! │   ├─ main.html
+//! │   └─ footer.html
+//! └─ assets/             ← 静的ファイル
+//! ```
+
+use std::path::{Path, PathBuf};
+
+use thiserror::Error;
+
+// ─────────────────────────────────────────────
+// エラー型
+// ─────────────────────────────────────────────
+
+/// output モジュールのエラー型
+#[derive(Debug, Error)]
+pub enum OutputError {
+    #[error("I/O error writing `{path}`: {source}")]
+    Io {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+}
+
+// ─────────────────────────────────────────────
+// OutputFile — 書き出し対象1件
+// ─────────────────────────────────────────────
+
+/// 書き出し対象のファイル1件
+#[derive(Debug, Clone)]
+pub struct OutputFile {
+    /// 出力先の相対パス（`output_dir` からの相対）
+    pub relative_path: String,
+    /// ファイル内容
+    pub content: String,
+    /// Cache-Control ヘッダー値（deploy 時に利用）
+    pub cache_control: Option<String>,
+}
+
+// ─────────────────────────────────────────────
+// write_output_files
+// ─────────────────────────────────────────────
+
+/// `OutputFile` のリストをディスクに書き出す
+///
+/// - `output_dir`: 書き出し先のルートディレクトリ
+/// - `files`: 書き出すファイルのリスト
+///
+/// 各ファイルの親ディレクトリが存在しない場合は自動的に作成する。
+pub fn write_output_files(
+    output_dir: &Path,
+    files: &[OutputFile],
+) -> Result<Vec<PathBuf>, OutputError> {
+    let mut written: Vec<PathBuf> = Vec::new();
+
+    for file in files {
+        let dest = output_dir.join(&file.relative_path);
+
+        // 親ディレクトリを作成
+        if let Some(parent) = dest.parent() {
+            std::fs::create_dir_all(parent).map_err(|source| OutputError::Io {
+                path: parent.to_path_buf(),
+                source,
+            })?;
+        }
+
+        // ファイル書き込み
+        std::fs::write(&dest, &file.content).map_err(|source| OutputError::Io {
+            path: dest.clone(),
+            source,
+        })?;
+
+        written.push(dest);
+    }
+
+    Ok(written)
+}
+
+/// `OutputFile` のリストを生成して返す（ディスク書き込みなし）
+///
+/// テスト・プレビューモード用。`index.html` を先頭に保証する。
+pub fn collect_output_files(
+    parent_html: String,
+    parts: Vec<crate::iframe::Part>,
+    part_htmls: Vec<String>,
+    index_name: &str,
+) -> Vec<OutputFile> {
+    let mut files: Vec<OutputFile> = Vec::new();
+
+    // 親ページ
+    files.push(OutputFile {
+        relative_path: index_name.to_string(),
+        content: parent_html,
+        cache_control: None,
+    });
+
+    // パーツ
+    for (part, html) in parts.iter().zip(part_htmls.iter()) {
+        files.push(OutputFile {
+            relative_path: part.output_path.clone(),
+            content: html.clone(),
+            cache_control: part.cache_control.clone(),
+        });
+    }
+
+    files
+}
+
+// ─────────────────────────────────────────────
+// Tests
+// ─────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::iframe::Part;
+    use tempfile::TempDir;
+
+    fn sample_parts() -> Vec<Part> {
+        vec![
+            Part {
+                id: "header".to_string(),
+                content: "<h1>H</h1>".to_string(),
+                output_path: "parts/header.html".to_string(),
+                cache_control: Some("max-age=3600".to_string()),
+            },
+            Part {
+                id: "footer".to_string(),
+                content: "<footer>F</footer>".to_string(),
+                output_path: "parts/footer.html".to_string(),
+                cache_control: None,
+            },
+        ]
+    }
+
+    #[test]
+    fn write_creates_files_and_dirs() {
+        let tmp = TempDir::new().unwrap();
+        let files = vec![
+            OutputFile {
+                relative_path: "index.html".to_string(),
+                content: "<html>parent</html>".to_string(),
+                cache_control: None,
+            },
+            OutputFile {
+                relative_path: "parts/header.html".to_string(),
+                content: "<html>header</html>".to_string(),
+                cache_control: Some("max-age=3600".to_string()),
+            },
+        ];
+
+        let written = write_output_files(tmp.path(), &files).unwrap();
+        assert_eq!(written.len(), 2);
+        assert!(tmp.path().join("index.html").exists());
+        assert!(tmp.path().join("parts/header.html").exists());
+
+        let content = std::fs::read_to_string(tmp.path().join("index.html")).unwrap();
+        assert!(content.contains("parent"));
+    }
+
+    #[test]
+    fn collect_output_files_index_first() {
+        let parts = sample_parts();
+        let part_htmls = vec![
+            "<html>header</html>".to_string(),
+            "<html>footer</html>".to_string(),
+        ];
+        let files = collect_output_files(
+            "<html>parent</html>".to_string(),
+            parts,
+            part_htmls,
+            "index.html",
+        );
+
+        assert_eq!(files[0].relative_path, "index.html");
+        assert_eq!(files[1].relative_path, "parts/header.html");
+        assert_eq!(files[2].relative_path, "parts/footer.html");
+        assert_eq!(files[1].cache_control, Some("max-age=3600".to_string()));
+        assert!(files[2].cache_control.is_none());
+    }
+
+    #[test]
+    fn output_dir_created_if_not_exists() {
+        let tmp = TempDir::new().unwrap();
+        let deep_dir = tmp.path().join("a/b/c");
+        let files = vec![OutputFile {
+            relative_path: "a/b/c/index.html".to_string(),
+            content: "x".to_string(),
+            cache_control: None,
+        }];
+        write_output_files(tmp.path(), &files).unwrap();
+        assert!(deep_dir.join("index.html").exists());
+    }
+}

--- a/crates/s3d-display/src/plugin.rs
+++ b/crates/s3d-display/src/plugin.rs
@@ -1,0 +1,283 @@
+//! PlainHtmlDisplay — DisplayPlugin のデフォルト実装
+//!
+//! React / Astro 等の外部フレームワークに依存せず、
+//! テンプレートリテラルのみで HTML を生成する。
+//!
+//! 将来の `display-react` / `display-astro` プラグインは
+//! `DisplayPlugin` trait を別クレートで実装する。
+
+use s3d_types::manifest::DeployManifest;
+use s3d_types::plugin::{DisplayPlugin, HtmlOutput, RenderContext};
+
+use crate::config::DisplayProjectConfig;
+use crate::iframe::partition_page;
+use crate::template::{render_parent_page, render_part_page, TemplateOptions};
+
+// ─────────────────────────────────────────────
+// PlainHtmlDisplay
+// ─────────────────────────────────────────────
+
+/// プレーン HTML 生成プラグイン
+///
+/// `DisplayProjectConfig` を保持し、`render()` で HTML ファイル群を返す。
+#[derive(Debug, Clone)]
+pub struct PlainHtmlDisplay {
+    /// display 側の設定
+    pub config: DisplayProjectConfig,
+}
+
+impl PlainHtmlDisplay {
+    /// 新しい `PlainHtmlDisplay` を作成する
+    pub fn new(config: DisplayProjectConfig) -> Self {
+        Self { config }
+    }
+}
+
+impl DisplayPlugin for PlainHtmlDisplay {
+    /// HTML ファイル群を生成して返す
+    ///
+    /// 1. `RenderContext` から `S3dConfig` と `DeployManifest` を受け取る
+    /// 2. `DisplayProjectConfig` の `assetsStrategy` を使ってテンプレートを構築
+    /// 3. `iframe` 設定に従い HTML を分割してパーツ HTML を生成
+    /// 4. 全 HTML ファイルを `Vec<HtmlOutput>` として返す
+    fn render(&self, context: &RenderContext) -> Vec<HtmlOutput> {
+        let cfg = &self.config;
+        let opts = TemplateOptions {
+            title: cfg.title(),
+            manifest_url: &cfg.manifest_url,
+            assets_strategy: &cfg.assets_strategy,
+            extra_head: cfg.extra_head.as_deref(),
+        };
+
+        // ダミーのボディ HTML（実際には RenderContext から取得するか外部から渡す）
+        // ここでは manifest の asset 一覧をデバッグ出力として使う簡易実装
+        let body_html = build_body_html(context.manifest);
+
+        // iframe 分割
+        let partition = partition_page(
+            &body_html,
+            &cfg.iframe.partition_rules,
+            cfg.iframe.iframe_attrs.as_deref(),
+        );
+
+        let mut outputs: Vec<HtmlOutput> = Vec::new();
+
+        // パーツ HTML 生成
+        let mut part_htmls: Vec<String> = Vec::new();
+        for part in &partition.parts {
+            let html = render_part_page(
+                &part.id,
+                &part.content,
+                part.cache_control.as_deref(),
+                &opts,
+            );
+            part_htmls.push(html.clone());
+            outputs.push(HtmlOutput {
+                path: part.output_path.clone(),
+                content: html,
+                cache_control: part.cache_control.clone(),
+            });
+        }
+
+        // 親ページ HTML 生成（先頭に追加）
+        let parent_html = render_parent_page(&partition.parent_content, &opts);
+        outputs.insert(
+            0,
+            HtmlOutput {
+                path: "index.html".to_string(),
+                content: parent_html,
+                cache_control: None,
+            },
+        );
+
+        outputs
+    }
+}
+
+/// manifest の asset 情報からデバッグ用の簡易ボディ HTML を生成する
+fn build_body_html(manifest: &DeployManifest) -> String {
+    let mut lines = vec![
+        format!("<div id=\"s3d-app\" data-version=\"{}\">", manifest.version),
+        "  <!-- s3d application root -->".to_string(),
+    ];
+
+    if !manifest.assets.is_empty() {
+        lines.push("  <ul id=\"s3d-assets\">".to_string());
+        let mut keys: Vec<&str> = manifest.assets.keys().map(String::as_str).collect();
+        keys.sort();
+        for key in keys {
+            lines.push(format!("    <li data-key=\"{}\"></li>", key));
+        }
+        lines.push("  </ul>".to_string());
+    }
+
+    lines.push("</div>".to_string());
+    lines.join("\n")
+}
+
+// ─────────────────────────────────────────────
+// Tests
+// ─────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    use s3d_loader::{
+        AssetsStrategyConfig, CdnStrategyConfig, InitialConfig, ReloadConfig, ReloadStrategy,
+        ReloadTrigger,
+    };
+    use s3d_types::config::{DeployConfig, DisplayConfig, LoaderDisplayConfig, S3dConfig};
+    use s3d_types::manifest::{AssetEntry, DeployManifest};
+
+    use crate::config::{DisplayProjectConfig, IframeConfig, IframePartRule};
+
+    fn sample_strategy() -> AssetsStrategyConfig {
+        AssetsStrategyConfig {
+            initial: InitialConfig {
+                sources: vec!["js/main.js".to_string()],
+                cache: true,
+                fallback: None,
+            },
+            cdn: CdnStrategyConfig {
+                files: vec!["models/**".to_string()],
+                cache: true,
+                max_age: None,
+            },
+            reload: ReloadConfig {
+                trigger: ReloadTrigger::ManifestChange,
+                strategy: ReloadStrategy::Diff,
+                interval_ms: None,
+            },
+        }
+    }
+
+    fn sample_manifest() -> DeployManifest {
+        let mut assets = HashMap::new();
+        assets.insert(
+            "js/main.js".to_string(),
+            AssetEntry {
+                url: "https://cdn.example.com/js/main.abc.js".to_string(),
+                size: 1024,
+                hash: "abc12345".to_string(),
+                content_type: "application/javascript".to_string(),
+                dependencies: None,
+            },
+        );
+        DeployManifest {
+            schema_version: 1,
+            version: "1.0.0".to_string(),
+            build_time: "2026-03-20T00:00:00Z".to_string(),
+            assets,
+        }
+    }
+
+    fn sample_s3d_config() -> S3dConfig {
+        S3dConfig {
+            schema_version: 1,
+            project: "test".to_string(),
+            deploy: None,
+            display: Some(DisplayConfig {
+                loader: LoaderDisplayConfig {
+                    concurrency: None,
+                    retry_count: None,
+                    retry_base_delay: None,
+                    timeout: None,
+                },
+            }),
+            draft: None,
+        }
+    }
+
+    fn make_plugin(with_parts: bool) -> PlainHtmlDisplay {
+        let rules = if with_parts {
+            vec![
+                IframePartRule {
+                    id: "header".to_string(),
+                    output_path: "parts/header.html".to_string(),
+                    cache_control: Some("max-age=3600".to_string()),
+                },
+                IframePartRule {
+                    id: "footer".to_string(),
+                    output_path: "parts/footer.html".to_string(),
+                    cache_control: None,
+                },
+            ]
+        } else {
+            vec![]
+        };
+
+        let config = DisplayProjectConfig {
+            output_dir: "output".to_string(),
+            manifest_url: "https://cdn.example.com/manifest.json".to_string(),
+            assets_strategy: sample_strategy(),
+            iframe: IframeConfig {
+                partition_rules: rules,
+                iframe_attrs: None,
+            },
+            title: Some("Test App".to_string()),
+            extra_head: None,
+        };
+        PlainHtmlDisplay::new(config)
+    }
+
+    #[test]
+    fn render_without_parts_produces_index_only() {
+        let plugin = make_plugin(false);
+        let s3d_config = sample_s3d_config();
+        let manifest = sample_manifest();
+        let context = RenderContext {
+            config: &s3d_config,
+            manifest: &manifest,
+        };
+
+        let outputs = plugin.render(&context);
+        assert_eq!(outputs.len(), 1);
+        assert_eq!(outputs[0].path, "index.html");
+        assert!(outputs[0].content.contains("<!DOCTYPE html>"));
+        assert!(outputs[0].content.contains("Test App"));
+    }
+
+    #[test]
+    fn render_body_html_contains_asset_keys() {
+        let manifest = sample_manifest();
+        let html = build_body_html(&manifest);
+        assert!(html.contains("js/main.js"));
+        assert!(html.contains("1.0.0"));
+    }
+
+    #[test]
+    fn render_with_iframe_parts_produces_multiple_files() {
+        let plugin = make_plugin(true);
+        let s3d_config = sample_s3d_config();
+
+        // パーツマーカーを含むボディを使うには iframe.rs の partition_page が必要
+        // ここではマーカーなしで呼ぶと parts が生成されないことを確認
+        let manifest = sample_manifest();
+        let context = RenderContext {
+            config: &s3d_config,
+            manifest: &manifest,
+        };
+        let outputs = plugin.render(&context);
+        // マーカーなしのボディなのでパーツは生成されず index.html のみ
+        assert_eq!(outputs[0].path, "index.html");
+    }
+
+    #[test]
+    fn render_output_contains_strategy_json() {
+        let plugin = make_plugin(false);
+        let s3d_config = sample_s3d_config();
+        let manifest = sample_manifest();
+        let context = RenderContext {
+            config: &s3d_config,
+            manifest: &manifest,
+        };
+
+        let outputs = plugin.render(&context);
+        assert!(outputs[0].content.contains("manifest-change"));
+        assert!(outputs[0]
+            .content
+            .contains("https://cdn.example.com/manifest.json"));
+    }
+}

--- a/crates/s3d-display/src/template.rs
+++ b/crates/s3d-display/src/template.rs
@@ -1,0 +1,283 @@
+//! HTML テンプレート生成モジュール
+//!
+//! 親ページ・パーツ HTML のテンプレートを生成する。
+//! `strategyAssets` の初期化スクリプトタグを埋め込み、
+//! Cache-Control を `<meta>` タグで表現する。
+//!
+//! ## 出力例（親ページ）
+//!
+//! ```html
+//! <!DOCTYPE html>
+//! <html lang="ja">
+//! <head>
+//!   <meta charset="UTF-8">
+//!   <title>My App</title>
+//!   <script type="application/json" id="s3d-strategy">{ ... }</script>
+//!   <script src="assets/s3d-loader.js" defer></script>
+//! </head>
+//! <body>
+//!   <!-- parent_body -->
+//! </body>
+//! </html>
+//! ```
+
+use s3d_loader::AssetsStrategyConfig;
+
+// ─────────────────────────────────────────────
+// TemplateOptions
+// ─────────────────────────────────────────────
+
+/// テンプレート生成オプション
+#[derive(Debug, Clone)]
+pub struct TemplateOptions<'a> {
+    /// ページタイトル
+    pub title: &'a str,
+    /// manifest URL
+    pub manifest_url: &'a str,
+    /// アセット配信戦略
+    pub assets_strategy: &'a AssetsStrategyConfig,
+    /// `<head>` に追加する HTML スニペット（省略可）
+    pub extra_head: Option<&'a str>,
+}
+
+// ─────────────────────────────────────────────
+// 親ページ HTML 生成
+// ─────────────────────────────────────────────
+
+/// 親ページの完全な HTML を生成する
+///
+/// `body_content` にはすでに `<iframe>` タグを含むパーツ分割済みの HTML が渡される。
+pub fn render_parent_page(body_content: &str, opts: &TemplateOptions<'_>) -> String {
+    let strategy_json =
+        serde_json::to_string_pretty(opts.assets_strategy).unwrap_or_else(|_| "{}".to_string());
+
+    let extra = opts.extra_head.unwrap_or("");
+
+    format!(
+        r#"<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>{title}</title>
+  <script type="application/json" id="s3d-strategy">
+{strategy_json}
+  </script>
+  <script type="text/javascript">
+    (function() {{
+      var cfg = JSON.parse(document.getElementById('s3d-strategy').textContent);
+      window.__S3D_CONFIG__ = {{
+        manifestUrl: {manifest_url_json},
+        strategy: cfg
+      }};
+    }})();
+  </script>{extra_head}
+</head>
+<body>
+{body_content}
+</body>
+</html>"#,
+        title = escape_html(opts.title),
+        strategy_json = strategy_json,
+        manifest_url_json = serde_json::to_string(opts.manifest_url).unwrap_or_default(),
+        extra_head = if extra.is_empty() {
+            String::new()
+        } else {
+            format!("\n  {}", extra)
+        },
+        body_content = body_content,
+    )
+}
+
+// ─────────────────────────────────────────────
+// パーツ HTML 生成
+// ─────────────────────────────────────────────
+
+/// パーツの完全な HTML を生成する
+///
+/// 各パーツは独立した HTML ファイルとして出力され、
+/// `cache_control` が指定されていれば `<meta>` タグとして埋め込む。
+pub fn render_part_page(
+    part_id: &str,
+    body_content: &str,
+    cache_control: Option<&str>,
+    opts: &TemplateOptions<'_>,
+) -> String {
+    let cc_meta = cache_control
+        .map(|cc| {
+            format!(
+                "\n  <meta http-equiv=\"Cache-Control\" content=\"{}\">",
+                escape_html(cc)
+            )
+        })
+        .unwrap_or_default();
+
+    let strategy_json =
+        serde_json::to_string_pretty(opts.assets_strategy).unwrap_or_else(|_| "{}".to_string());
+
+    format!(
+        r#"<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>{title} — {part_id}</title>{cc_meta}
+  <script type="application/json" id="s3d-strategy">
+{strategy_json}
+  </script>
+  <script type="text/javascript">
+    (function() {{
+      var cfg = JSON.parse(document.getElementById('s3d-strategy').textContent);
+      window.__S3D_CONFIG__ = {{
+        manifestUrl: {manifest_url_json},
+        strategy: cfg,
+        partId: {part_id_json}
+      }};
+    }})();
+  </script>
+</head>
+<body>
+{body_content}
+</body>
+</html>"#,
+        title = escape_html(opts.title),
+        part_id = escape_html(part_id),
+        cc_meta = cc_meta,
+        strategy_json = strategy_json,
+        manifest_url_json = serde_json::to_string(opts.manifest_url).unwrap_or_default(),
+        part_id_json = serde_json::to_string(part_id).unwrap_or_default(),
+        body_content = body_content,
+    )
+}
+
+// ─────────────────────────────────────────────
+// ヘルパー
+// ─────────────────────────────────────────────
+
+/// HTML 特殊文字をエスケープする（タイトル等に使用）
+fn escape_html(s: &str) -> String {
+    s.replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+        .replace('"', "&quot;")
+        .replace('\'', "&#39;")
+}
+
+// ─────────────────────────────────────────────
+// Tests
+// ─────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use s3d_loader::{
+        AssetsStrategyConfig, CdnStrategyConfig, InitialConfig, ReloadConfig, ReloadStrategy,
+        ReloadTrigger,
+    };
+
+    fn sample_strategy() -> AssetsStrategyConfig {
+        AssetsStrategyConfig {
+            initial: InitialConfig {
+                sources: vec!["js/main.js".to_string()],
+                cache: true,
+                fallback: None,
+            },
+            cdn: CdnStrategyConfig {
+                files: vec!["models/**".to_string()],
+                cache: true,
+                max_age: None,
+            },
+            reload: ReloadConfig {
+                trigger: ReloadTrigger::ManifestChange,
+                strategy: ReloadStrategy::Diff,
+                interval_ms: None,
+            },
+        }
+    }
+
+    fn sample_opts(strategy: &AssetsStrategyConfig) -> TemplateOptions<'_> {
+        TemplateOptions {
+            title: "Test App",
+            manifest_url: "https://cdn.example.com/manifest.json",
+            assets_strategy: strategy,
+            extra_head: None,
+        }
+    }
+
+    #[test]
+    fn parent_page_contains_doctype() {
+        let strategy = sample_strategy();
+        let opts = sample_opts(&strategy);
+        let html = render_parent_page("<p>body</p>", &opts);
+        assert!(html.starts_with("<!DOCTYPE html>"));
+    }
+
+    #[test]
+    fn parent_page_contains_title() {
+        let strategy = sample_strategy();
+        let opts = sample_opts(&strategy);
+        let html = render_parent_page("", &opts);
+        assert!(html.contains("<title>Test App</title>"));
+    }
+
+    #[test]
+    fn parent_page_contains_strategy_json() {
+        let strategy = sample_strategy();
+        let opts = sample_opts(&strategy);
+        let html = render_parent_page("", &opts);
+        assert!(html.contains(r#"id="s3d-strategy""#));
+        assert!(html.contains("manifest-change"));
+    }
+
+    #[test]
+    fn parent_page_contains_manifest_url() {
+        let strategy = sample_strategy();
+        let opts = sample_opts(&strategy);
+        let html = render_parent_page("", &opts);
+        assert!(html.contains("https://cdn.example.com/manifest.json"));
+    }
+
+    #[test]
+    fn parent_page_extra_head_inserted() {
+        let strategy = sample_strategy();
+        let mut opts = sample_opts(&strategy);
+        opts.extra_head = Some(r#"<link rel="stylesheet" href="style.css">"#);
+        let html = render_parent_page("", &opts);
+        assert!(html.contains(r#"<link rel="stylesheet""#));
+    }
+
+    #[test]
+    fn part_page_contains_cache_control_meta() {
+        let strategy = sample_strategy();
+        let opts = sample_opts(&strategy);
+        let html = render_part_page("header", "<h1>Hi</h1>", Some("max-age=3600"), &opts);
+        assert!(html.contains("Cache-Control"));
+        assert!(html.contains("max-age=3600"));
+    }
+
+    #[test]
+    fn part_page_no_cache_control_when_none() {
+        let strategy = sample_strategy();
+        let opts = sample_opts(&strategy);
+        let html = render_part_page("main", "<p>Content</p>", None, &opts);
+        assert!(!html.contains("Cache-Control"));
+    }
+
+    #[test]
+    fn part_page_contains_part_id_in_config() {
+        let strategy = sample_strategy();
+        let opts = sample_opts(&strategy);
+        let html = render_part_page("footer", "<footer>F</footer>", None, &opts);
+        assert!(html.contains("\"footer\""));
+    }
+
+    #[test]
+    fn html_title_is_escaped() {
+        let strategy = sample_strategy();
+        let mut opts = sample_opts(&strategy);
+        opts.title = "<script>alert(1)</script>";
+        let html = render_parent_page("", &opts);
+        assert!(html.contains("&lt;script&gt;"));
+        assert!(!html.contains("<script>alert(1)</script>"));
+    }
+}


### PR DESCRIPTION
## 概要

Issue #8 の実装として `crates/s3d-display` クレートを追加します。
フロント開発者が display 層だけで完結できる HTML 生成インターフェースと iframe 正規化を提供します。

## 新規ファイル

| ファイル | 説明 |
|---|---|
| `Cargo.toml` | s3d-types / s3d-loader / serde / serde_json / thiserror |
| `src/config.rs` | `DisplayProjectConfig` — output_dir / manifest_url / assetsStrategy / iframe 設定・バリデーション |
| `src/iframe.rs` | `partition_page()` — `<!-- s3d-part: id -->` マーカーで HTML をパーツ分割、親ページを `<iframe>` タグに置換 |
| `src/template.rs` | `render_parent_page()` / `render_part_page()` — strategyAssets JSON 埋め込み・Cache-Control meta タグ・XSS エスケープ |
| `src/output.rs` | `write_output_files()` — OutputFile リストをディスクに書き出し（親ディレクトリ自動作成） |
| `src/plugin.rs` | `PlainHtmlDisplay` — `DisplayPlugin` trait の実装（React/Vue 非依存） |
| `src/lib.rs` | 全型の再エクスポート・`write_outputs()` 便利関数 |

## iframe 正規化フロー

```html
<!-- 入力 HTML -->
<!-- s3d-part: header -->
<header><h1>Title</h1></header>
<!-- s3d-part-end -->

<!-- 出力: 親ページ -->
<iframe src="parts/header.html" width="100%" frameborder="0"></iframe>

<!-- 出力: parts/header.html -->
<!DOCTYPE html>
<html>...<body><header><h1>Title</h1></header></body></html>
```

## 出力ディレクトリ構造

```
output/
├─ index.html          ← 親ページ（iframe でパーツを参照）
├─ parts/
│   ├─ header.html
│   ├─ main.html
│   └─ footer.html
└─ assets/
```

## テスト結果

```
unit: 28 passed / doctest: 1 passed / total: 29 passed, 0 failed
```

Closes #8