### PR TITLE
feat(s3d-display): iframe dynamic data markers + fix dead_code warnings — Closes #10

### DIFF
--- a/crates/s3d-display/src/config.rs
+++ b/crates/s3d-display/src/config.rs
@@ -159,9 +159,7 @@ impl DisplayProjectConfig {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use s3d_loader::{
-        CdnStrategyConfig, InitialConfig, ReloadConfig, ReloadStrategy, ReloadTrigger,
-    };
+    use s3d_loader::{ReloadStrategy, ReloadTrigger};
 
     fn sample_json() -> String {
         serde_json::json!({

--- a/crates/s3d-display/src/iframe.rs
+++ b/crates/s3d-display/src/iframe.rs
@@ -1,20 +1,32 @@
 //! iframe 正規化モジュール
 //!
+//! 2種類のマーカー変換をサポートする:
+//!
+//! ## 1. `s3d-part` — コンテンツ分割型
+//!
 //! HTML を `<!-- s3d-part: <id> -->` コメントマーカーでパーツに分割し、
 //! 各パーツを独立 HTML ファイルとして出力する。
 //! 親ページは `<iframe src="parts/<id>.html">` でパーツを参照する。
 //!
-//! ## マーカー書式
-//!
-//! ```html
+//! ```text
 //! <!-- s3d-part: header -->
 //! <header>...</header>
 //! <!-- s3d-part-end -->
 //! ```
 //!
-//! - 開始マーカー: `<!-- s3d-part: <id> -->`
-//! - 終了マーカー: `<!-- s3d-part-end -->`
-//! - マーカー間のコンテンツがパーツ HTML のボディになる
+//! ## 2. `s3d-iframe` — 動的データ領域の切り出し型 (Issue #10)
+//!
+//! SSGページ内の動的データ領域（価格、在庫数、ステータス等）をiframeとして切り出す。
+//! データ変更時に親ページの再ビルドを不要にし、差分取得対象にできる。
+//!
+//! ```text
+//! <!-- s3d-iframe: price-123 src="parts/price-123.html" -->
+//! ```
+//!
+//! - マーカーは単体タグ（開始/終了なし）— そのまま `<iframe>` タグに変換
+//! - 参照先 HTML は別途生成・配置する（このマーカーはリンクのみ）
+//! - `data-s3d-id` 属性でクライアント側から識別可能
+//! - 親ページは長期キャッシュ、iframe 参照先は短期キャッシュを推奨
 
 use crate::config::IframePartRule;
 
@@ -174,6 +186,125 @@ fn resolve_rule(rules: &[IframePartRule], id: &str) -> (String, Option<String>) 
 }
 
 // ─────────────────────────────────────────────
+// s3d-iframe マーカー変換 (Issue #10)
+// ─────────────────────────────────────────────
+
+/// `<!-- s3d-iframe: {id} src="{url}" -->` マーカーの変換結果
+#[derive(Debug, Clone, PartialEq)]
+pub struct IframeMarker {
+    /// `data-s3d-id` に設定される識別子
+    pub id: String,
+    /// iframe の `src` 属性値
+    pub src: String,
+}
+
+/// HTML 内の `<!-- s3d-iframe: {id} src="{url}" -->` を
+/// `<iframe src="{url}" data-s3d-id="{id}" ...>` タグに変換する
+///
+/// ## 引数
+/// - `html`: 変換対象の HTML 文字列
+/// - `iframe_attrs`: `<iframe>` タグに追加する属性文字列（省略時はデフォルト属性）
+///
+/// ## 戻り値
+/// `(変換後 HTML, 発見したマーカー一覧)`
+///
+/// マーカーが 1 件も見つからない場合は元の HTML をそのまま返す。
+pub fn replace_iframe_markers(
+    html: &str,
+    iframe_attrs: Option<&str>,
+) -> (String, Vec<IframeMarker>) {
+    let attrs = iframe_attrs.unwrap_or("width=\"100%\" frameborder=\"0\"");
+    let mut result = String::with_capacity(html.len());
+    let mut markers: Vec<IframeMarker> = Vec::new();
+    let mut remaining = html;
+
+    while !remaining.is_empty() {
+        if let Some(pos) = find_iframe_marker(remaining) {
+            // マーカー前のテキストをそのまま追加
+            result.push_str(&remaining[..pos.marker_start]);
+
+            // `<iframe>` タグに変換
+            result.push_str(&format!(
+                "<iframe src=\"{}\" data-s3d-id=\"{}\" {}></iframe>",
+                pos.src, pos.id, attrs
+            ));
+
+            markers.push(IframeMarker {
+                id: pos.id,
+                src: pos.src,
+            });
+
+            remaining = &remaining[pos.marker_end..];
+        } else {
+            result.push_str(remaining);
+            remaining = "";
+        }
+    }
+
+    (result, markers)
+}
+
+// ─────────────────────────────────────────────
+// s3d-iframe 内部ヘルパー
+// ─────────────────────────────────────────────
+
+struct IframeMarkerPos {
+    marker_start: usize,
+    marker_end: usize,
+    id: String,
+    src: String,
+}
+
+/// `<!-- s3d-iframe: {id} src="{url}" -->` を探してパースする
+///
+/// 書式: `<!-- s3d-iframe: <id> src="<url>" -->`
+/// - `<id>` は空白を含まないトークン
+/// - `src="..."` は二重引用符で囲まれた URL
+fn find_iframe_marker(html: &str) -> Option<IframeMarkerPos> {
+    const PREFIX: &str = "<!-- s3d-iframe:";
+    const SUFFIX: &str = "-->";
+
+    let start = html.find(PREFIX)?;
+    let after_prefix = &html[start + PREFIX.len()..];
+    let end_rel = after_prefix.find(SUFFIX)?;
+    let inner = after_prefix[..end_rel].trim();
+
+    // inner を空白で分割: 先頭が id、残りに `src="..."` が含まれる
+    // 例: `price-123 src="parts/price-123.html"`
+    let (id, rest) = inner.split_once(char::is_whitespace)?;
+    let id = id.trim().to_string();
+    if id.is_empty() {
+        return None;
+    }
+
+    // src="..." を抽出
+    let src = parse_src_attr(rest.trim())?;
+
+    let marker_end = start + PREFIX.len() + end_rel + SUFFIX.len();
+
+    Some(IframeMarkerPos {
+        marker_start: start,
+        marker_end,
+        id,
+        src,
+    })
+}
+
+/// `src="<url>"` または `src='<url>'` から URL 文字列を抽出する
+fn parse_src_attr(s: &str) -> Option<String> {
+    // `src=` を探す
+    let src_pos = s.find("src=")?;
+    let after_eq = &s[src_pos + 4..]; // "src=" の後
+    let quote = after_eq.chars().next()?;
+    if quote != '"' && quote != '\'' {
+        return None;
+    }
+    let content = &after_eq[1..];
+    let end = content.find(quote)?;
+    Some(content[..end].to_string())
+}
+
+// ─────────────────────────────────────────────
 // Tests
 // ─────────────────────────────────────────────
 
@@ -270,5 +401,89 @@ mod tests {
         let html = "<!-- s3d-part: main -->\n  <p>hi</p>\n<!-- s3d-part-end -->";
         let result = partition_page(html, &rules(), None);
         assert_eq!(result.parts[0].content, "<p>hi</p>");
+    }
+
+    // ─────────────────────────────────────────────
+    // s3d-iframe マーカー変換テスト (Issue #10)
+    // ─────────────────────────────────────────────
+
+    #[test]
+    fn iframe_marker_basic_conversion() {
+        let html = r#"<div><!-- s3d-iframe: price-123 src="parts/price-123.html" --></div>"#;
+        let (out, markers) = replace_iframe_markers(html, None);
+
+        assert_eq!(markers.len(), 1);
+        assert_eq!(markers[0].id, "price-123");
+        assert_eq!(markers[0].src, "parts/price-123.html");
+
+        assert!(out.contains(r#"src="parts/price-123.html""#));
+        assert!(out.contains(r#"data-s3d-id="price-123""#));
+        // 元のマーカーコメントは消えている
+        assert!(!out.contains("s3d-iframe:"));
+    }
+
+    #[test]
+    fn iframe_marker_multiple_markers() {
+        let html = concat!(
+            r#"<!-- s3d-iframe: price-1 src="parts/price-1.html" -->"#,
+            r#"<!-- s3d-iframe: stock-1 src="parts/stock-1.html" -->"#,
+        );
+        let (out, markers) = replace_iframe_markers(html, None);
+
+        assert_eq!(markers.len(), 2);
+        assert_eq!(markers[0].id, "price-1");
+        assert_eq!(markers[1].id, "stock-1");
+        assert!(out.contains("parts/price-1.html"));
+        assert!(out.contains("parts/stock-1.html"));
+    }
+
+    #[test]
+    fn iframe_marker_no_markers_returns_original() {
+        let html = "<p>no markers here</p>";
+        let (out, markers) = replace_iframe_markers(html, None);
+        assert_eq!(out, html);
+        assert!(markers.is_empty());
+    }
+
+    #[test]
+    fn iframe_marker_custom_attrs() {
+        let html = r#"<!-- s3d-iframe: x src="x.html" -->"#;
+        let (out, _) = replace_iframe_markers(html, Some(r#"loading="lazy""#));
+        assert!(out.contains(r#"loading="lazy""#));
+    }
+
+    #[test]
+    fn iframe_marker_preserves_surrounding_html() {
+        let html =
+            r#"<header>TOP</header><!-- s3d-iframe: price src="p.html" --><footer>BOT</footer>"#;
+        let (out, _) = replace_iframe_markers(html, None);
+        assert!(out.starts_with("<header>TOP</header>"));
+        assert!(out.ends_with("<footer>BOT</footer>"));
+        assert!(out.contains("<iframe"));
+    }
+
+    #[test]
+    fn iframe_marker_with_single_quote_src() {
+        let html = "<!-- s3d-iframe: abc src='parts/abc.html' -->";
+        let (out, markers) = replace_iframe_markers(html, None);
+        assert_eq!(markers[0].src, "parts/abc.html");
+        assert!(out.contains("parts/abc.html"));
+    }
+
+    #[test]
+    fn both_markers_work_together() {
+        let html = concat!(
+            "<!-- s3d-part: header --><h1>H</h1><!-- s3d-part-end -->",
+            r#"<p><!-- s3d-iframe: price src="parts/price.html" --></p>"#,
+        );
+        // まず s3d-part で分割
+        let partition = partition_page(html, &rules(), None);
+        assert_eq!(partition.parts.len(), 1);
+
+        // 次に親ページ内の s3d-iframe を変換
+        let (final_html, markers) = replace_iframe_markers(&partition.parent_content, None);
+        assert_eq!(markers.len(), 1);
+        assert_eq!(markers[0].id, "price");
+        assert!(final_html.contains(r#"data-s3d-id="price""#));
     }
 }

--- a/crates/s3d-display/src/lib.rs
+++ b/crates/s3d-display/src/lib.rs
@@ -40,7 +40,7 @@ pub mod template;
 
 // 主要な型を再エクスポート
 pub use config::{ConfigError, DisplayProjectConfig, IframeConfig, IframePartRule};
-pub use iframe::{partition_page, IframePartition, Part};
+pub use iframe::{partition_page, replace_iframe_markers, IframeMarker, IframePartition, Part};
 pub use output::{collect_output_files, write_output_files, OutputError, OutputFile};
 pub use plugin::PlainHtmlDisplay;
 pub use template::{render_parent_page, render_part_page, TemplateOptions};
@@ -79,33 +79,9 @@ mod tests {
     use std::collections::HashMap;
     use tempfile::TempDir;
 
-    use s3d_loader::{
-        AssetsStrategyConfig, CdnStrategyConfig, InitialConfig, ReloadConfig, ReloadStrategy,
-        ReloadTrigger,
-    };
     use s3d_types::config::{DisplayConfig, LoaderDisplayConfig, S3dConfig};
     use s3d_types::manifest::{AssetEntry, DeployManifest};
     use s3d_types::plugin::{DisplayPlugin, RenderContext};
-
-    fn sample_strategy() -> AssetsStrategyConfig {
-        AssetsStrategyConfig {
-            initial: InitialConfig {
-                sources: vec!["js/main.js".to_string()],
-                cache: true,
-                fallback: None,
-            },
-            cdn: CdnStrategyConfig {
-                files: vec!["models/**".to_string()],
-                cache: true,
-                max_age: None,
-            },
-            reload: ReloadConfig {
-                trigger: ReloadTrigger::ManifestChange,
-                strategy: ReloadStrategy::Diff,
-                interval_ms: None,
-            },
-        }
-    }
 
     fn sample_manifest() -> DeployManifest {
         let mut assets = HashMap::new();

--- a/crates/s3d-display/src/plugin.rs
+++ b/crates/s3d-display/src/plugin.rs
@@ -128,7 +128,7 @@ mod tests {
         AssetsStrategyConfig, CdnStrategyConfig, InitialConfig, ReloadConfig, ReloadStrategy,
         ReloadTrigger,
     };
-    use s3d_types::config::{DeployConfig, DisplayConfig, LoaderDisplayConfig, S3dConfig};
+    use s3d_types::config::{DisplayConfig, LoaderDisplayConfig, S3dConfig};
     use s3d_types::manifest::{AssetEntry, DeployManifest};
 
     use crate::config::{DisplayProjectConfig, IframeConfig, IframePartRule};


### PR DESCRIPTION
## 概要

Issue #10 の実装と追加タスク（dead_code warning 修正）をまとめて対応します。

---

## Issue #10: `s3d-iframe` マーカー — 動的データ領域の切り出し

### 新関数: `replace_iframe_markers(html, iframe_attrs)`

`crates/s3d-display/src/iframe.rs` に追加。

**マーカー書式:**
```html
<!-- s3d-iframe: price-123 src="parts/price-123.html" -->
```

**変換後:**
```html
<iframe src="parts/price-123.html" data-s3d-id="price-123" width="100%" frameborder="0"></iframe>
```

### 設計上の利点

| 課題 | 解決 |
|---|---|
| 価格1件変更で100ページ再ビルド | iframe 参照先 HTML だけ更新 |
| 親ページを長期キャッシュしたい | 親ページは変更なし → `max-age` 長く設定可 |
| 差分取得対象にしたい | `cdn.files` に参照先パターンを追加するだけ |
| SEO への影響 | 親ページが安定しクローラ評価が安定 |

### `s3d-part` との組み合わせ

```
partition_page(html, rules, attrs)     ← コンテンツ分割
    ↓ parent_content
replace_iframe_markers(parent, attrs)  ← 動的データ領域リンク
    ↓ 最終的な親ページ HTML
```

### 新規テスト (7件)

| テスト | 確認内容 |
|---|---|
| `iframe_marker_basic_conversion` | 基本変換・`data-s3d-id` 付与 |
| `iframe_marker_multiple_markers` | 複数マーカーの一括変換 |
| `iframe_marker_no_markers_returns_original` | マーカーなし → 変更なし |
| `iframe_marker_custom_attrs` | カスタム属性の反映 |
| `iframe_marker_preserves_surrounding_html` | 前後 HTML の保持 |
| `iframe_marker_with_single_quote_src` | 単引用符 src の対応 |
| `both_markers_work_together` | `s3d-part` と `s3d-iframe` の併用 |

---

## 追加タスク: dead_code / unused import 警告修正

| ファイル | 修正内容 |
|---|---|
| `lib.rs` | `sample_strategy()` 削除（テストで未使用）・不要 import 整理 |
| `config.rs` | `CdnStrategyConfig`, `InitialConfig`, `ReloadConfig` の未使用 import 削除 |
| `plugin.rs` | `DeployConfig` の未使用 import 削除 |

---

## テスト結果

```
cargo test -p s3d-display --lib --tests

35 passed; 0 failed; 0 ignored
0 warnings
```

Closes #10