### PR TITLE
feat(s3d-cli): add s3d-cli crate — init/build/diff/push/validate — Closes #12

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+S3D_ACCESS_KEY_ID=your_access_key_id
+S3D_SECRET_ACCESS_KEY=your_secret_access_key

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target
+.env

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,65 @@ dependencies = [
 ]
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "anstream"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
+name = "anstyle-parse"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -43,6 +102,12 @@ name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
+name = "autocfg"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "base64"
@@ -104,12 +169,95 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "chrono"
+version = "0.4.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+dependencies = [
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "serde",
+ "wasm-bindgen",
+ "windows-link",
+]
+
+[[package]]
+name = "clap"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
+
+[[package]]
+name = "colored"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
+dependencies = [
+ "lazy_static",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "colored"
 version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "console"
+version = "0.15.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "once_cell",
+ "unicode-width",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -148,6 +296,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "dialoguer"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "658bce805d770f407bc62102fca7c2c64ceef2fbcb2b8bd19d2765ce093980de"
+dependencies = [
+ "console",
+ "shell-words",
+ "tempfile",
+ "thiserror 1.0.69",
+ "zeroize",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -155,6 +316,7 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -169,6 +331,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "dotenvy"
+version = "0.15.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
+
+[[package]]
+name = "encode_unicode"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -181,7 +355,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -415,6 +589,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
+
+[[package]]
 name = "http"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -519,6 +702,30 @@ dependencies = [
  "tokio",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -658,6 +865,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -672,6 +885,12 @@ dependencies = [
  "once_cell",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "leb128fmt"
@@ -742,7 +961,7 @@ checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
 dependencies = [
  "libc",
  "wasi",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -753,7 +972,7 @@ checksum = "90820618712cab19cfc46b274c6c22546a82affcb3c3bdf0f29e3db8e1bb92c0"
 dependencies = [
  "assert-json-diff",
  "bytes",
- "colored",
+ "colored 3.1.1",
  "futures-core",
  "http",
  "http-body",
@@ -788,10 +1007,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "openssl"
@@ -1055,7 +1289,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1078,6 +1312,31 @@ name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "s3d-cli"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "chrono",
+ "clap",
+ "colored 2.2.0",
+ "dialoguer",
+ "dotenvy",
+ "futures",
+ "hex",
+ "hmac",
+ "mockito",
+ "reqwest",
+ "s3d-deploy",
+ "s3d-types",
+ "serde",
+ "serde_json",
+ "sha2",
+ "tempfile",
+ "tokio",
+]
 
 [[package]]
 name = "s3d-deploy"
@@ -1148,7 +1407,7 @@ version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1253,6 +1512,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "shell-words"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc6fe69c597f9c37bfeeeeeb33da3530379845f10be461a66d16d03eca2ded77"
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1283,7 +1548,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1291,6 +1556,18 @@ name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
@@ -1333,7 +1610,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1399,7 +1676,7 @@ dependencies = [
  "pin-project-lite",
  "socket2",
  "tokio-macros",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1525,6 +1802,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+
+[[package]]
 name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1547,6 +1830,12 @@ name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "vcpkg"
@@ -1712,7 +2001,42 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1722,6 +2046,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
 name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1729,6 +2080,70 @@ checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "wit-bindgen"

--- a/README.md
+++ b/README.md
@@ -1,0 +1,95 @@
+# s3d — Static 3D Asset Deployment
+
+**s3d** は 3D アセット（`.glb`, `.gltf`, `.ktx2` 等）の CDN デプロイを自動化する Rust ツールチェーンです。
+
+## クレート構成
+
+| クレート | 説明 |
+|---|---|
+| [`s3d-types`](crates/s3d-types/) | 共通型定義（`CollectedAsset`, `HashedAsset`, `DeployManifest`, `StoragePlugin` トレイトなど） |
+| [`s3d-deploy`](crates/s3d-deploy/) | アセット収集・SHA-256 ハッシュ化・マニフェスト生成・差分計算 |
+| [`s3d-loader`](crates/s3d-loader/) | フロントエンド向けアセットローダー（assetsStrategy / strategyAssets） |
+| [`s3d-display`](crates/s3d-display/) | HTML 生成・iframe 正規化（DisplayPlugin トレイト） |
+| [`s3d-cli`](crates/s3d-cli/) | CLI バイナリ `s3d`（init / build / diff / push / validate） |
+
+## アーキテクチャ
+
+```
+[output/]  ─→  s3d-deploy  ─→  manifest.json
+                   │
+                   ▼
+              s3d-cli push  ─→  Cloudflare R2 / AWS S3
+                   │
+                   ▼
+           s3d-loader (browser)  ─→  assetsStrategy / strategyAssets
+                   │
+                   ▼
+           s3d-display  ─→  HTML + iframe 正規化
+```
+
+## クイックスタート
+
+```bash
+# 1. プロジェクト初期化（インタラクティブ）
+s3d init
+
+# 2. .env に認証情報を記入
+cp .env.example .env
+# S3D_ACCESS_KEY_ID / S3D_SECRET_ACCESS_KEY を設定
+
+# 3. アセットを output/ に配置
+cp -r dist/ output/
+
+# 4. ビルド（マニフェスト生成）
+s3d build
+
+# 5. 差分確認（オプション）
+s3d diff --old old-manifest.json output/manifest.json
+
+# 6. R2/S3 へアップロード
+s3d push
+
+# 7. ドライラン（実際にはアップロードしない）
+s3d push --dry-run
+```
+
+## s3d.config.json
+
+```json
+{
+  "project": "my-3d-project",
+  "storage": {
+    "provider": "cloudflare-r2",
+    "bucket": "my-assets-bucket",
+    "cdn_base_url": "https://cdn.example.com",
+    "account_id": "your_cloudflare_account_id"
+  },
+  "output_dir": "output",
+  "include": [],
+  "exclude": ["**/.DS_Store"]
+}
+```
+
+## 環境変数
+
+| 変数名 | 説明 |
+|---|---|
+| `S3D_ACCESS_KEY_ID` | R2/S3 アクセスキー ID |
+| `S3D_SECRET_ACCESS_KEY` | R2/S3 シークレットアクセスキー |
+
+## ビルド
+
+```bash
+# 全クレートのビルド
+cargo build
+
+# テスト
+cargo test
+
+# CLI バイナリのビルド
+cargo build -p s3d-cli --release
+```
+
+## ライセンス
+
+MIT

--- a/crates/s3d-cli/Cargo.toml
+++ b/crates/s3d-cli/Cargo.toml
@@ -1,0 +1,58 @@
+[package]
+name = "s3d-cli"
+version = "0.1.0"
+edition = "2021"
+description = "s3d — static 3D asset deployment CLI"
+default-run = "s3d"
+
+[[bin]]
+name = "s3d"
+path = "src/main.rs"
+
+[dependencies]
+s3d-types  = { path = "../s3d-types" }
+s3d-deploy = { path = "../s3d-deploy" }
+
+# CLI argument parsing
+clap = { version = "4", features = ["derive"] }
+
+# Coloured terminal output
+colored = "2"
+
+# Error handling
+anyhow = "1"
+
+# Async runtime
+tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros"] }
+
+# HTTP client for R2/S3 REST API
+reqwest = { version = "0.12", default-features = false, features = ["json", "native-tls"] }
+
+# HMAC-SHA256 for AWS Signature V4
+hmac   = "0.12"
+sha2   = "0.10"
+hex    = "0.4"
+
+# .env loading
+dotenvy = "0.15"
+
+# Interactive prompts
+dialoguer = "0.11"
+
+# Serialization
+serde      = { version = "1", features = ["derive"] }
+serde_json = "1"
+
+# Time (URL signing)
+chrono = { version = "0.4", features = ["serde"] }
+
+# Async traits
+async-trait = "0.1"
+
+# Futures
+futures = "0.3"
+
+[dev-dependencies]
+tempfile = "3"
+tokio    = { version = "1", features = ["rt", "rt-multi-thread", "macros"] }
+mockito  = "1"

--- a/crates/s3d-cli/src/commands/build.rs
+++ b/crates/s3d-cli/src/commands/build.rs
@@ -1,0 +1,152 @@
+//! `s3d build` — アセット収集・ハッシュ化・マニフェスト生成コマンド
+
+use std::path::Path;
+use std::time::Instant;
+
+use anyhow::{Context, Result};
+use colored::Colorize;
+use s3d_deploy::{
+    collect::{collect, CollectOptions},
+    hash::hash_assets,
+    manifest::{build_manifest, manifest_to_json, ManifestOptions},
+};
+
+use crate::config::S3dCliConfig;
+
+/// `s3d build` を実行する
+pub fn run(config: &S3dCliConfig, config_path: &Path) -> Result<()> {
+    let start = Instant::now();
+    let project_root = config_path.parent().unwrap_or(Path::new("."));
+    let output_dir = project_root.join(&config.output_dir);
+
+    println!("{}", "s3d build — アセットをビルドします".bold().cyan());
+    println!("  入力ディレクトリ : {}", output_dir.display());
+
+    // ── 1. 収集
+    let collect_opts = CollectOptions {
+        ignore: config.exclude.clone(),
+        include: config.include.clone(),
+        max_file_size: config.max_file_size.clone(),
+    };
+    let collected = collect(&output_dir, &collect_opts)
+        .with_context(|| format!("アセット収集エラー: {}", output_dir.display()))?;
+    println!("  収集: {} ファイル", collected.len().to_string().bold());
+
+    // ── 2. ハッシュ化
+    let hashed = hash_assets(&collected, s3d_deploy::hash::DEFAULT_HASH_LENGTH)
+        .context("ハッシュ計算エラー")?;
+
+    // ── 3. マニフェスト生成
+    let manifest_opts = ManifestOptions {
+        cdn_base_url: config
+            .storage
+            .cdn_base_url
+            .trim_end_matches('/')
+            .to_string(),
+        version: "1.0.0".to_string(),
+        build_time: Some(chrono::Utc::now().to_rfc3339()),
+    };
+    let manifest = build_manifest(&hashed, &manifest_opts).context("マニフェスト生成エラー")?;
+
+    // ── 4. manifest.json の書き込み
+    let manifest_path = config.resolved_manifest_path();
+    let manifest_path = if manifest_path.is_absolute() {
+        manifest_path
+    } else {
+        project_root.join(&manifest_path)
+    };
+    if let Some(parent) = manifest_path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let json = manifest_to_json(&manifest).context("マニフェスト JSON 変換エラー")?;
+    std::fs::write(&manifest_path, &json)
+        .with_context(|| format!("manifest.json の書き込み失敗: {}", manifest_path.display()))?;
+
+    // ── サマリ表示
+    let total_size: u64 = hashed.iter().map(|a| a.size).sum();
+    let elapsed = start.elapsed();
+    println!();
+    println!("{}", "ビルド完了 ✔".green().bold());
+    println!("  ファイル数   : {}", hashed.len().to_string().bold());
+    println!("  合計サイズ   : {}", format_bytes(total_size).bold());
+    println!(
+        "  manifest.json: {}",
+        manifest_path.display().to_string().bold()
+    );
+    println!("  ビルド時間   : {:.2}s", elapsed.as_secs_f64());
+
+    Ok(())
+}
+
+fn format_bytes(bytes: u64) -> String {
+    if bytes >= 1_073_741_824 {
+        format!("{:.2} GB", bytes as f64 / 1_073_741_824.0)
+    } else if bytes >= 1_048_576 {
+        format!("{:.2} MB", bytes as f64 / 1_048_576.0)
+    } else if bytes >= 1024 {
+        format!("{:.2} KB", bytes as f64 / 1024.0)
+    } else {
+        format!("{} B", bytes)
+    }
+}
+
+// ──────────────────────────────────────────────────────────────
+// Tests
+// ──────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::{CdnProvider, S3dCliConfig, StorageConfig};
+    use tempfile::TempDir;
+
+    fn make_config(output_dir: &str) -> S3dCliConfig {
+        S3dCliConfig {
+            project: "test".to_string(),
+            storage: StorageConfig {
+                provider: CdnProvider::CloudflareR2,
+                bucket: "bucket".to_string(),
+                cdn_base_url: "https://cdn.example.com".to_string(),
+                account_id: None,
+                endpoint: None,
+                region: None,
+            },
+            output_dir: output_dir.to_string(),
+            include: vec![],
+            exclude: vec![],
+            max_file_size: None,
+            manifest_path: None,
+        }
+    }
+
+    #[test]
+    fn test_build_creates_manifest() {
+        let dir = TempDir::new().unwrap();
+        let output = dir.path().join("output");
+        std::fs::create_dir_all(&output).unwrap();
+        // ダミーアセット
+        std::fs::write(output.join("app.js"), b"console.log('hello');").unwrap();
+        std::fs::write(output.join("style.css"), b"body { margin: 0; }").unwrap();
+
+        let config_path = dir.path().join("s3d.config.json");
+        let cfg = make_config("output");
+        crate::config::save_config(&config_path, &cfg).unwrap();
+
+        run(&cfg, &config_path).unwrap();
+
+        let manifest_path = dir.path().join("output/manifest.json");
+        assert!(manifest_path.exists(), "manifest.json が生成されていない");
+        let content = std::fs::read_to_string(&manifest_path).unwrap();
+        assert!(
+            content.contains("app.js") || content.contains("app."),
+            "app.js がマニフェストに含まれていない"
+        );
+    }
+
+    #[test]
+    fn test_format_bytes() {
+        assert_eq!(format_bytes(500), "500 B");
+        assert_eq!(format_bytes(1024), "1.00 KB");
+        assert_eq!(format_bytes(1_048_576), "1.00 MB");
+    }
+}

--- a/crates/s3d-cli/src/commands/diff.rs
+++ b/crates/s3d-cli/src/commands/diff.rs
@@ -1,0 +1,141 @@
+//! `s3d diff` — 2 つのマニフェストを比較してコンソールに表示するコマンド
+
+use std::path::Path;
+
+use anyhow::{Context, Result};
+use colored::Colorize;
+use s3d_deploy::diff::{diff_manifests, DiffEntry};
+use s3d_types::asset::AssetDiff;
+use s3d_types::manifest::DeployManifest;
+
+/// `s3d diff` を実行する
+///
+/// `old_path`: 旧 manifest.json のパス（`None` = 初回デプロイ扱い）
+/// `new_path`: 新 manifest.json のパス
+pub fn run(old_path: Option<&Path>, new_path: &Path) -> Result<()> {
+    println!("{}", "s3d diff — マニフェスト差分".bold().cyan());
+
+    let new_manifest = load_manifest(new_path)?;
+    let old_manifest = old_path.map(load_manifest).transpose()?;
+
+    let entries = diff_manifests(old_manifest.as_ref(), &new_manifest);
+
+    print_diff(&entries);
+
+    Ok(())
+}
+
+fn load_manifest(path: &Path) -> Result<DeployManifest> {
+    let content = std::fs::read_to_string(path)
+        .with_context(|| format!("マニフェストの読み込み失敗: {}", path.display()))?;
+    serde_json::from_str(&content)
+        .with_context(|| format!("マニフェストのパース失敗: {}", path.display()))
+}
+
+pub fn print_diff(entries: &[DiffEntry]) {
+    let mut added = 0usize;
+    let mut modified = 0usize;
+    let mut deleted = 0usize;
+    let mut unchanged = 0usize;
+
+    for e in entries {
+        match e.diff {
+            AssetDiff::Added => {
+                println!("  {} {}", "+".green().bold(), e.key);
+                added += 1;
+            }
+            AssetDiff::Modified => {
+                println!("  {} {}", "~".yellow().bold(), e.key);
+                modified += 1;
+            }
+            AssetDiff::Deleted => {
+                println!("  {} {}", "-".red().bold(), e.key);
+                deleted += 1;
+            }
+            AssetDiff::Unchanged => {
+                unchanged += 1;
+            }
+        }
+    }
+
+    println!();
+    println!(
+        "  {} 追加  {} 変更  {} 削除  {} 変更なし",
+        added.to_string().green().bold(),
+        modified.to_string().yellow().bold(),
+        deleted.to_string().red().bold(),
+        unchanged.to_string().dimmed(),
+    );
+}
+
+// ──────────────────────────────────────────────────────────────
+// Tests
+// ──────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use s3d_deploy::diff::DiffEntry;
+    use s3d_types::asset::AssetDiff;
+
+    #[test]
+    fn test_print_diff_counts() {
+        let entries = vec![
+            DiffEntry {
+                key: "a.js".to_string(),
+                diff: AssetDiff::Added,
+            },
+            DiffEntry {
+                key: "b.css".to_string(),
+                diff: AssetDiff::Modified,
+            },
+            DiffEntry {
+                key: "c.png".to_string(),
+                diff: AssetDiff::Deleted,
+            },
+            DiffEntry {
+                key: "d.glb".to_string(),
+                diff: AssetDiff::Unchanged,
+            },
+        ];
+        // should not panic
+        print_diff(&entries);
+    }
+
+    #[test]
+    fn test_run_with_files() {
+        use s3d_types::manifest::{AssetEntry, DeployManifest};
+        use std::collections::HashMap;
+        use tempfile::NamedTempFile;
+
+        let make_manifest = |keys: &[&str]| -> String {
+            let mut assets = HashMap::new();
+            for k in keys {
+                assets.insert(
+                    k.to_string(),
+                    AssetEntry {
+                        url: format!("https://cdn.example.com/{k}"),
+                        size: 100,
+                        hash: "aabbccdd".to_string(),
+                        content_type: "text/plain".to_string(),
+                        dependencies: None,
+                    },
+                );
+            }
+            let m = DeployManifest {
+                schema_version: 1,
+                version: "1.0.0".to_string(),
+                build_time: "2026-01-01T00:00:00Z".to_string(),
+                assets,
+            };
+            serde_json::to_string_pretty(&m).unwrap()
+        };
+
+        let old_file = NamedTempFile::new().unwrap();
+        let new_file = NamedTempFile::new().unwrap();
+        std::fs::write(old_file.path(), make_manifest(&["a.js", "b.css"])).unwrap();
+        std::fs::write(new_file.path(), make_manifest(&["a.js", "c.glb"])).unwrap();
+
+        run(Some(old_file.path()), new_file.path()).unwrap();
+    }
+}

--- a/crates/s3d-cli/src/commands/init.rs
+++ b/crates/s3d-cli/src/commands/init.rs
@@ -1,0 +1,186 @@
+//! `s3d init` — プロジェクト初期化コマンド
+//!
+//! インタラクティブなプロンプトで設定を収集し
+//! `s3d.config.json`, `.env.example`, `.gitignore`, `output/` を生成する。
+
+use anyhow::Result;
+use colored::Colorize;
+use dialoguer::{Input, Select};
+
+use crate::config::{save_config, CdnProvider, S3dCliConfig, StorageConfig};
+
+const PROVIDERS: &[&str] = &["cloudflare-r2", "aws-s3", "custom"];
+
+/// `s3d init` を実行する
+pub fn run() -> Result<()> {
+    println!("{}", "s3d init — プロジェクトの初期化".bold().cyan());
+    println!();
+
+    // ── プロジェクト名
+    let project: String = Input::new()
+        .with_prompt("プロジェクト名")
+        .default("my-project".to_string())
+        .interact_text()?;
+
+    // ── CDN プロバイダー
+    let provider_idx = Select::new()
+        .with_prompt("CDN プロバイダー")
+        .items(PROVIDERS)
+        .default(0)
+        .interact()?;
+    let provider = match provider_idx {
+        1 => CdnProvider::AwsS3,
+        2 => CdnProvider::Custom,
+        _ => CdnProvider::CloudflareR2,
+    };
+
+    // ── バケット名
+    let bucket: String = Input::new().with_prompt("バケット名").interact_text()?;
+
+    // ── CDN ベース URL
+    let cdn_base_url: String = Input::new()
+        .with_prompt("CDN ベース URL (例: https://cdn.example.com)")
+        .interact_text()?;
+
+    // ── アカウント ID (R2 のみ)
+    let account_id = if provider == CdnProvider::CloudflareR2 {
+        let id: String = Input::new()
+            .with_prompt("Cloudflare アカウント ID (省略可)")
+            .allow_empty(true)
+            .interact_text()?;
+        if id.is_empty() {
+            None
+        } else {
+            Some(id)
+        }
+    } else {
+        None
+    };
+
+    // ── リージョン (S3 のみ)
+    let region = if provider == CdnProvider::AwsS3 {
+        let r: String = Input::new()
+            .with_prompt("AWS リージョン (例: ap-northeast-1)")
+            .default("us-east-1".to_string())
+            .interact_text()?;
+        Some(r)
+    } else {
+        None
+    };
+
+    // ── 設定ファイルを生成
+    let config = S3dCliConfig {
+        project: project.clone(),
+        storage: StorageConfig {
+            provider,
+            bucket,
+            cdn_base_url,
+            account_id,
+            endpoint: None,
+            region,
+        },
+        output_dir: "output".to_string(),
+        include: vec![],
+        exclude: vec![],
+        max_file_size: None,
+        manifest_path: None,
+    };
+
+    save_config(std::path::Path::new("s3d.config.json"), &config)?;
+    println!("{}", "✔ s3d.config.json を生成しました".green());
+
+    // ── .env.example
+    std::fs::write(
+        ".env.example",
+        "S3D_ACCESS_KEY_ID=your_access_key_id\n\
+         S3D_SECRET_ACCESS_KEY=your_secret_access_key\n",
+    )?;
+    println!("{}", "✔ .env.example を生成しました".green());
+
+    // ── .gitignore
+    let gitignore_path = std::path::Path::new(".gitignore");
+    let mut gitignore_content = if gitignore_path.exists() {
+        std::fs::read_to_string(gitignore_path)?
+    } else {
+        String::new()
+    };
+    for entry in ["/target", ".env"] {
+        if !gitignore_content.contains(entry) {
+            if !gitignore_content.ends_with('\n') && !gitignore_content.is_empty() {
+                gitignore_content.push('\n');
+            }
+            gitignore_content.push_str(entry);
+            gitignore_content.push('\n');
+        }
+    }
+    std::fs::write(".gitignore", &gitignore_content)?;
+    println!("{}", "✔ .gitignore を更新しました".green());
+
+    // ── output/ ディレクトリ
+    std::fs::create_dir_all("output")?;
+    println!("{}", "✔ output/ ディレクトリを作成しました".green());
+
+    println!();
+    println!("{}", "次のステップ:".bold());
+    println!("  1. cp .env.example .env  # R2/S3 の認証情報を記入");
+    println!("  2. アセットを output/ に配置");
+    println!("  3. s3d build              # マニフェスト生成");
+    println!("  4. s3d push               # R2/S3 へアップロード");
+
+    Ok(())
+}
+
+// ──────────────────────────────────────────────────────────────
+// Tests
+// ──────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use crate::config::{load_config, save_config, CdnProvider, S3dCliConfig, StorageConfig};
+    use tempfile::TempDir;
+
+    /// init が生成するファイルのテスト（プロンプトなしで直接生成）
+    #[test]
+    fn test_generate_files() {
+        let dir = TempDir::new().unwrap();
+        let orig = std::env::current_dir().unwrap();
+        std::env::set_current_dir(dir.path()).unwrap();
+
+        let config = S3dCliConfig {
+            project: "test-project".to_string(),
+            storage: StorageConfig {
+                provider: CdnProvider::CloudflareR2,
+                bucket: "test-bucket".to_string(),
+                cdn_base_url: "https://cdn.example.com".to_string(),
+                account_id: Some("acc123".to_string()),
+                endpoint: None,
+                region: None,
+            },
+            output_dir: "output".to_string(),
+            include: vec![],
+            exclude: vec![],
+            max_file_size: None,
+            manifest_path: None,
+        };
+        save_config(std::path::Path::new("s3d.config.json"), &config).unwrap();
+
+        // .env.example
+        std::fs::write(
+            ".env.example",
+            "S3D_ACCESS_KEY_ID=your_access_key_id\nS3D_SECRET_ACCESS_KEY=your_secret_access_key\n",
+        )
+        .unwrap();
+
+        // output/
+        std::fs::create_dir_all("output").unwrap();
+
+        assert!(std::path::Path::new("s3d.config.json").exists());
+        assert!(std::path::Path::new(".env.example").exists());
+        assert!(std::path::Path::new("output").is_dir());
+
+        let loaded = load_config(std::path::Path::new("s3d.config.json")).unwrap();
+        assert_eq!(loaded.project, "test-project");
+
+        std::env::set_current_dir(&orig).unwrap();
+    }
+}

--- a/crates/s3d-cli/src/commands/mod.rs
+++ b/crates/s3d-cli/src/commands/mod.rs
@@ -1,0 +1,7 @@
+//! commands モジュール
+
+pub mod build;
+pub mod diff;
+pub mod init;
+pub mod push;
+pub mod validate;

--- a/crates/s3d-cli/src/commands/push.rs
+++ b/crates/s3d-cli/src/commands/push.rs
@@ -1,0 +1,355 @@
+//! `s3d push` — アセットを R2/S3 へアップロードするコマンド
+
+use std::path::Path;
+use std::sync::Arc;
+
+use anyhow::{Context, Result};
+use colored::Colorize;
+use futures::future::join_all;
+use s3d_deploy::diff::{diff_manifests, needs_delete, needs_upload};
+use s3d_types::manifest::DeployManifest;
+use s3d_types::plugin::StoragePlugin;
+
+use crate::config::S3dCliConfig;
+
+/// `s3d push` を実行する
+///
+/// `dry_run = true` の場合は実際の I/O を行わず差分のみ表示する。
+pub async fn run(
+    config: &S3dCliConfig,
+    config_path: &Path,
+    manifest_path_override: Option<&Path>,
+    dry_run: bool,
+    storage: Arc<dyn StoragePlugin>,
+) -> Result<()> {
+    println!(
+        "{}",
+        "s3d push — アセットをアップロードします".bold().cyan()
+    );
+
+    let project_root = config_path.parent().unwrap_or(Path::new("."));
+    let output_dir = project_root.join(&config.output_dir);
+
+    // ── ローカル manifest.json を読む
+    let local_manifest_path = manifest_path_override
+        .map(|p| p.to_path_buf())
+        .unwrap_or_else(|| {
+            let mp = config.resolved_manifest_path();
+            if mp.is_absolute() {
+                mp
+            } else {
+                project_root.join(&mp)
+            }
+        });
+
+    let new_manifest = load_local_manifest(&local_manifest_path)?;
+
+    // ── R2 から旧 manifest.json を取得
+    let old_manifest = fetch_remote_manifest(storage.as_ref(), "manifest.json").await;
+
+    // ── 差分計算
+    let entries = diff_manifests(old_manifest.as_ref(), &new_manifest);
+    let to_upload = needs_upload(&entries);
+    let to_delete = needs_delete(&entries);
+
+    if to_upload.is_empty() && to_delete.is_empty() {
+        println!("{}", "変更なし。アップロードは不要です。".dimmed());
+        return Ok(());
+    }
+
+    println!(
+        "  アップロード: {} ファイル  削除: {} ファイル",
+        to_upload.len().to_string().green().bold(),
+        to_delete.len().to_string().red().bold(),
+    );
+
+    if dry_run {
+        println!(
+            "{}",
+            "[dry-run] 実際のアップロードはスキップします".yellow()
+        );
+        for key in &to_upload {
+            println!("  {} {}", "↑".green(), key);
+        }
+        for key in &to_delete {
+            println!("  {} {}", "✕".red(), key);
+        }
+        return Ok(());
+    }
+
+    // ── アップロード（並列）
+    let concurrency = 8usize;
+    let upload_keys: Vec<String> = to_upload.iter().map(|s| s.to_string()).collect();
+    let total = upload_keys.len();
+    let counter = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+
+    for chunk in upload_keys.chunks(concurrency) {
+        let futures: Vec<_> = chunk
+            .iter()
+            .map(|key| {
+                let storage = Arc::clone(&storage);
+                let key = key.clone();
+                let output_dir = output_dir.clone();
+                let new_manifest = new_manifest.clone();
+                let counter = Arc::clone(&counter);
+                let total = total;
+
+                async move {
+                    // manifest からハッシュ付きキーを探す（URL から元のキー特定）
+                    // ローカルファイルは output_dir/key として読み込む
+                    let file_path = output_dir.join(&key);
+                    match std::fs::read(&file_path) {
+                        Ok(data) => {
+                            let content_type = new_manifest
+                                .assets
+                                .get(&key)
+                                .map(|e| e.content_type.as_str())
+                                .unwrap_or("application/octet-stream");
+                            match storage.put(&key, &data, content_type).await {
+                                Ok(_) => {
+                                    let done = counter
+                                        .fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+                                        + 1;
+                                    eprintln!("  [{done}/{total}] {} {key}", "↑".green());
+                                }
+                                Err(e) => {
+                                    eprintln!("  {} {key}: {}", "✘".red(), e.message);
+                                }
+                            }
+                        }
+                        Err(e) => {
+                            eprintln!("  {} ファイル読み込み失敗 {key}: {e}", "✘".red());
+                        }
+                    }
+                }
+            })
+            .collect();
+        join_all(futures).await;
+    }
+
+    // ── 削除
+    for key in &to_delete {
+        match storage.delete(key).await {
+            Ok(_) => println!("  {} {}", "✕".red(), key),
+            Err(e) => eprintln!("  {} 削除失敗 {key}: {}", "✘".red(), e.message),
+        }
+    }
+
+    // ── manifest.json をアップロード
+    let manifest_json =
+        serde_json::to_vec_pretty(&new_manifest).context("manifest JSON 変換失敗")?;
+    storage
+        .put("manifest.json", &manifest_json, "application/json")
+        .await
+        .map_err(|e| anyhow::anyhow!("manifest.json アップロード失敗: {}", e.message))?;
+    println!("  {} manifest.json をアップロードしました", "✔".green());
+
+    println!();
+    println!(
+        "{}  {} ファイルをアップロードしました",
+        "push 完了 ✔".green().bold(),
+        total.to_string().bold()
+    );
+
+    Ok(())
+}
+
+fn load_local_manifest(path: &Path) -> Result<DeployManifest> {
+    let content = std::fs::read_to_string(path)
+        .with_context(|| format!("manifest.json が見つかりません: {}", path.display()))?;
+    serde_json::from_str(&content)
+        .with_context(|| format!("manifest.json のパース失敗: {}", path.display()))
+}
+
+async fn fetch_remote_manifest(storage: &dyn StoragePlugin, key: &str) -> Option<DeployManifest> {
+    match storage.get(key).await {
+        Ok(data) => serde_json::from_slice(&data).ok(),
+        Err(_) => None, // 初回デプロイ時は None
+    }
+}
+
+// ──────────────────────────────────────────────────────────────
+// Tests
+// ──────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use async_trait::async_trait;
+    use s3d_types::plugin::{StorageError, StorageResult};
+    use std::collections::HashMap;
+    use std::sync::Mutex;
+
+    /// インメモリのモックストレージ
+    struct MockStorage {
+        data: Mutex<HashMap<String, Vec<u8>>>,
+    }
+
+    impl MockStorage {
+        fn new() -> Self {
+            Self {
+                data: Mutex::new(HashMap::new()),
+            }
+        }
+    }
+
+    #[async_trait]
+    impl StoragePlugin for MockStorage {
+        async fn put(&self, key: &str, data: &[u8], _ct: &str) -> StorageResult<()> {
+            self.data
+                .lock()
+                .unwrap()
+                .insert(key.to_string(), data.to_vec());
+            Ok(())
+        }
+        async fn get(&self, key: &str) -> StorageResult<Vec<u8>> {
+            self.data
+                .lock()
+                .unwrap()
+                .get(key)
+                .cloned()
+                .ok_or_else(|| StorageError {
+                    message: "not found".into(),
+                    key: Some(key.into()),
+                })
+        }
+        async fn delete(&self, key: &str) -> StorageResult<()> {
+            self.data.lock().unwrap().remove(key);
+            Ok(())
+        }
+        async fn list(&self, prefix: &str) -> StorageResult<Vec<String>> {
+            let keys: Vec<String> = self
+                .data
+                .lock()
+                .unwrap()
+                .keys()
+                .filter(|k| k.starts_with(prefix))
+                .cloned()
+                .collect();
+            Ok(keys)
+        }
+    }
+
+    fn make_config() -> S3dCliConfig {
+        crate::config::S3dCliConfig {
+            project: "test".to_string(),
+            storage: crate::config::StorageConfig {
+                provider: crate::config::CdnProvider::CloudflareR2,
+                bucket: "bucket".to_string(),
+                cdn_base_url: "https://cdn.example.com".to_string(),
+                account_id: None,
+                endpoint: None,
+                region: None,
+            },
+            output_dir: "output".to_string(),
+            include: vec![],
+            exclude: vec![],
+            max_file_size: None,
+            manifest_path: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn test_push_dry_run() {
+        use s3d_types::manifest::{AssetEntry, DeployManifest};
+        use tempfile::TempDir;
+
+        let dir = TempDir::new().unwrap();
+        let output = dir.path().join("output");
+        std::fs::create_dir_all(&output).unwrap();
+        std::fs::write(output.join("app.js"), b"console.log(1);").unwrap();
+
+        // マニフェストを手で作る
+        let mut assets = HashMap::new();
+        assets.insert(
+            "app.js".to_string(),
+            AssetEntry {
+                url: "https://cdn.example.com/app.abcd1234.js".to_string(),
+                size: 16,
+                hash: "abcd1234".to_string(),
+                content_type: "application/javascript".to_string(),
+                dependencies: None,
+            },
+        );
+        let manifest = DeployManifest {
+            schema_version: 1,
+            version: "1.0.0".to_string(),
+            build_time: "2026-01-01T00:00:00Z".to_string(),
+            assets,
+        };
+        let manifest_path = dir.path().join("output/manifest.json");
+        std::fs::write(
+            &manifest_path,
+            serde_json::to_string_pretty(&manifest).unwrap(),
+        )
+        .unwrap();
+
+        let cfg_path = dir.path().join("s3d.config.json");
+        let cfg = make_config();
+        crate::config::save_config(&cfg_path, &cfg).unwrap();
+
+        let storage: Arc<dyn StoragePlugin> = Arc::new(MockStorage::new());
+        run(&cfg, &cfg_path, Some(&manifest_path), true, storage)
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_push_no_changes() {
+        use s3d_types::manifest::{AssetEntry, DeployManifest};
+        use tempfile::TempDir;
+
+        let dir = TempDir::new().unwrap();
+        let output = dir.path().join("output");
+        std::fs::create_dir_all(&output).unwrap();
+
+        let mut assets = HashMap::new();
+        assets.insert(
+            "app.js".to_string(),
+            AssetEntry {
+                url: "https://cdn.example.com/app.abcd1234.js".to_string(),
+                size: 16,
+                hash: "abcd1234".to_string(),
+                content_type: "application/javascript".to_string(),
+                dependencies: None,
+            },
+        );
+        let manifest = DeployManifest {
+            schema_version: 1,
+            version: "1.0.0".to_string(),
+            build_time: "2026-01-01T00:00:00Z".to_string(),
+            assets: assets.clone(),
+        };
+        let manifest_path = dir.path().join("output/manifest.json");
+        std::fs::write(
+            &manifest_path,
+            serde_json::to_string_pretty(&manifest).unwrap(),
+        )
+        .unwrap();
+
+        let cfg_path = dir.path().join("s3d.config.json");
+        let cfg = make_config();
+        crate::config::save_config(&cfg_path, &cfg).unwrap();
+
+        // ストレージに同じ manifest を事前に入れておく → 差分なし
+        let storage = Arc::new(MockStorage::new());
+        {
+            let manifest_json = serde_json::to_vec_pretty(&manifest).unwrap();
+            storage
+                .put("manifest.json", &manifest_json, "application/json")
+                .await
+                .unwrap();
+        }
+        let storage: Arc<dyn StoragePlugin> = storage;
+
+        run(
+            &cfg,
+            &cfg_path,
+            Some(&manifest_path),
+            false,
+            Arc::clone(&storage),
+        )
+        .await
+        .unwrap();
+    }
+}

--- a/crates/s3d-cli/src/commands/validate.rs
+++ b/crates/s3d-cli/src/commands/validate.rs
@@ -1,0 +1,124 @@
+//! `s3d validate` — s3d.config.json と .env の検証コマンド
+
+use std::path::Path;
+
+use anyhow::Result;
+use colored::Colorize;
+
+use crate::config::{load_config, validate_config_and_env, S3dCliConfig};
+
+/// `s3d validate` を実行する
+pub fn run(config_path: &Path) -> Result<()> {
+    println!("{}", "s3d validate — 設定の検証".bold().cyan());
+
+    // ── config 読み込み
+    let config = match load_config(config_path) {
+        Ok(c) => {
+            println!("  {} s3d.config.json を読み込みました", "✔".green());
+            c
+        }
+        Err(e) => {
+            println!("  {} {}", "✘".red(), e);
+            return Ok(());
+        }
+    };
+
+    // ── 検証
+    let errors = validate_config_and_env(&config);
+
+    if errors.is_empty() {
+        print_success(&config);
+    } else {
+        for e in &errors {
+            println!("  {} {}", "✘".red(), e);
+        }
+        println!();
+        println!("{}", "検証に失敗しました".red().bold());
+    }
+
+    Ok(())
+}
+
+fn print_success(config: &S3dCliConfig) {
+    println!("  {} project       : {}", "✔".green(), config.project);
+    println!(
+        "  {} provider      : {}",
+        "✔".green(),
+        config.storage.provider
+    );
+    println!(
+        "  {} bucket        : {}",
+        "✔".green(),
+        config.storage.bucket
+    );
+    println!(
+        "  {} cdn_base_url  : {}",
+        "✔".green(),
+        config.storage.cdn_base_url
+    );
+    println!("  {} output_dir    : {}", "✔".green(), config.output_dir);
+    println!(
+        "  {} S3D_ACCESS_KEY_ID     : {}",
+        "✔".green(),
+        mask_env("S3D_ACCESS_KEY_ID")
+    );
+    println!(
+        "  {} S3D_SECRET_ACCESS_KEY : {}",
+        "✔".green(),
+        mask_env("S3D_SECRET_ACCESS_KEY")
+    );
+    println!();
+    println!("{}", "すべての検証が通過しました ✔".green().bold());
+}
+
+fn mask_env(var: &str) -> String {
+    match std::env::var(var) {
+        Ok(v) if v.len() > 4 => format!("{}****", &v[..4]),
+        Ok(v) if !v.is_empty() => "****".to_string(),
+        _ => "(未設定)".red().to_string(),
+    }
+}
+
+// ──────────────────────────────────────────────────────────────
+// Tests
+// ──────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::{save_config, CdnProvider, S3dCliConfig, StorageConfig};
+    use tempfile::TempDir;
+
+    #[test]
+    fn test_validate_missing_config() {
+        let dir = TempDir::new().unwrap();
+        let cfg_path = dir.path().join("s3d.config.json");
+        // ファイルが存在しない場合はエラーではなく "✘" を表示するだけ
+        run(&cfg_path).unwrap();
+    }
+
+    #[test]
+    fn test_validate_valid_config() {
+        let dir = TempDir::new().unwrap();
+        let cfg_path = dir.path().join("s3d.config.json");
+        let cfg = S3dCliConfig {
+            project: "proj".to_string(),
+            storage: StorageConfig {
+                provider: CdnProvider::CloudflareR2,
+                bucket: "bkt".to_string(),
+                cdn_base_url: "https://cdn.example.com".to_string(),
+                account_id: None,
+                endpoint: None,
+                region: None,
+            },
+            output_dir: "output".to_string(),
+            include: vec![],
+            exclude: vec![],
+            max_file_size: None,
+            manifest_path: None,
+        };
+        save_config(&cfg_path, &cfg).unwrap();
+        // 環境変数なしでも run は panic しない
+        run(&cfg_path).unwrap();
+    }
+}

--- a/crates/s3d-cli/src/config.rs
+++ b/crates/s3d-cli/src/config.rs
@@ -1,0 +1,218 @@
+//! s3d.config.json の読み込み・書き込みと `.env` ロード
+
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+
+// ──────────────────────────────────────────────────────────────
+// Config structs
+// ──────────────────────────────────────────────────────────────
+
+/// CDN プロバイダー
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "kebab-case")]
+pub enum CdnProvider {
+    CloudflareR2,
+    AwsS3,
+    Custom,
+}
+
+impl Default for CdnProvider {
+    fn default() -> Self {
+        Self::CloudflareR2
+    }
+}
+
+impl std::fmt::Display for CdnProvider {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::CloudflareR2 => write!(f, "cloudflare-r2"),
+            Self::AwsS3 => write!(f, "aws-s3"),
+            Self::Custom => write!(f, "custom"),
+        }
+    }
+}
+
+/// ストレージ設定
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct StorageConfig {
+    pub provider: CdnProvider,
+    pub bucket: String,
+    pub cdn_base_url: String,
+    /// R2: アカウントID (Cloudflare R2 使用時)
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub account_id: Option<String>,
+    /// カスタムエンドポイント（R2 互換 S3 など）
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub endpoint: Option<String>,
+    /// AWS リージョン (S3 使用時)
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub region: Option<String>,
+}
+
+/// プロジェクト設定 (s3d.config.json)
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct S3dCliConfig {
+    pub project: String,
+    pub storage: StorageConfig,
+    /// アセット収集のルートディレクトリ（デフォルト: "output"）
+    #[serde(default = "default_output_dir")]
+    pub output_dir: String,
+    /// glob パターン（デフォルト: 空 = 全ファイル）
+    #[serde(default)]
+    pub include: Vec<String>,
+    /// 除外パターン
+    #[serde(default)]
+    pub exclude: Vec<String>,
+    /// 最大ファイルサイズ（例: "100MB"）
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_file_size: Option<String>,
+    /// manifest.json の出力先（デフォルト: output_dir）
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub manifest_path: Option<String>,
+}
+
+fn default_output_dir() -> String {
+    "output".to_string()
+}
+
+impl S3dCliConfig {
+    /// manifest.json のパスを解決する
+    pub fn resolved_manifest_path(&self) -> PathBuf {
+        if let Some(p) = &self.manifest_path {
+            PathBuf::from(p)
+        } else {
+            PathBuf::from(&self.output_dir).join("manifest.json")
+        }
+    }
+}
+
+// ──────────────────────────────────────────────────────────────
+// Load / Save helpers
+// ──────────────────────────────────────────────────────────────
+
+/// `.env` をロードする（ファイルがなくても無視）
+pub fn load_dotenv() {
+    let _ = dotenvy::dotenv();
+}
+
+/// s3d.config.json を読み込む
+pub fn load_config(path: &Path) -> Result<S3dCliConfig> {
+    let content = std::fs::read_to_string(path)
+        .with_context(|| format!("s3d.config.json が見つかりません: {}", path.display()))?;
+    let config: S3dCliConfig =
+        serde_json::from_str(&content).context("s3d.config.json のパースに失敗しました")?;
+    Ok(config)
+}
+
+/// s3d.config.json を保存する
+pub fn save_config(path: &Path, config: &S3dCliConfig) -> Result<()> {
+    let content =
+        serde_json::to_string_pretty(config).context("config の JSON シリアライズに失敗")?;
+    std::fs::write(path, content).with_context(|| format!("書き込み失敗: {}", path.display()))?;
+    Ok(())
+}
+
+/// 設定と環境変数を検証し、不足があればエラーメッセージを返す
+pub fn validate_config_and_env(config: &S3dCliConfig) -> Vec<String> {
+    let mut errors = Vec::new();
+
+    if config.project.trim().is_empty() {
+        errors.push("project が空です".to_string());
+    }
+    if config.storage.bucket.trim().is_empty() {
+        errors.push("storage.bucket が空です".to_string());
+    }
+    if config.storage.cdn_base_url.trim().is_empty() {
+        errors.push("storage.cdn_base_url が空です".to_string());
+    }
+
+    // 必須環境変数
+    let required_env = match config.storage.provider {
+        CdnProvider::CloudflareR2 => vec!["S3D_ACCESS_KEY_ID", "S3D_SECRET_ACCESS_KEY"],
+        CdnProvider::AwsS3 => vec!["S3D_ACCESS_KEY_ID", "S3D_SECRET_ACCESS_KEY"],
+        CdnProvider::Custom => vec!["S3D_ACCESS_KEY_ID", "S3D_SECRET_ACCESS_KEY"],
+    };
+    for var in required_env {
+        if std::env::var(var).unwrap_or_default().trim().is_empty() {
+            errors.push(format!("環境変数 {var} が未設定です"));
+        }
+    }
+
+    errors
+}
+
+// ──────────────────────────────────────────────────────────────
+// Tests
+// ──────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::NamedTempFile;
+
+    fn sample_config() -> S3dCliConfig {
+        S3dCliConfig {
+            project: "my-project".to_string(),
+            storage: StorageConfig {
+                provider: CdnProvider::CloudflareR2,
+                bucket: "my-bucket".to_string(),
+                cdn_base_url: "https://cdn.example.com".to_string(),
+                account_id: Some("abc123".to_string()),
+                endpoint: None,
+                region: None,
+            },
+            output_dir: "output".to_string(),
+            include: vec![],
+            exclude: vec![],
+            max_file_size: None,
+            manifest_path: None,
+        }
+    }
+
+    #[test]
+    fn test_save_and_load_config() {
+        let tmp = NamedTempFile::new().unwrap();
+        let cfg = sample_config();
+        save_config(tmp.path(), &cfg).unwrap();
+        let loaded = load_config(tmp.path()).unwrap();
+        assert_eq!(loaded.project, "my-project");
+        assert_eq!(loaded.storage.bucket, "my-bucket");
+        assert_eq!(loaded.storage.provider, CdnProvider::CloudflareR2);
+    }
+
+    #[test]
+    fn test_resolved_manifest_path_default() {
+        let cfg = sample_config();
+        assert_eq!(
+            cfg.resolved_manifest_path(),
+            PathBuf::from("output/manifest.json")
+        );
+    }
+
+    #[test]
+    fn test_resolved_manifest_path_custom() {
+        let mut cfg = sample_config();
+        cfg.manifest_path = Some("dist/manifest.json".to_string());
+        assert_eq!(
+            cfg.resolved_manifest_path(),
+            PathBuf::from("dist/manifest.json")
+        );
+    }
+
+    #[test]
+    fn test_validate_missing_fields() {
+        let mut cfg = sample_config();
+        cfg.project = "".to_string();
+        // env vars not set in test — errors will include env vars too
+        let errs = validate_config_and_env(&cfg);
+        assert!(errs.iter().any(|e| e.contains("project")));
+    }
+
+    #[test]
+    fn test_cdn_provider_display() {
+        assert_eq!(CdnProvider::CloudflareR2.to_string(), "cloudflare-r2");
+        assert_eq!(CdnProvider::AwsS3.to_string(), "aws-s3");
+    }
+}

--- a/crates/s3d-cli/src/main.rs
+++ b/crates/s3d-cli/src/main.rs
@@ -1,0 +1,143 @@
+//! s3d CLI — エントリポイント
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use anyhow::Result;
+use clap::{Parser, Subcommand};
+use colored::Colorize;
+use s3d_types::plugin::StoragePlugin;
+
+mod commands;
+pub mod config;
+pub mod storage;
+
+use config::{load_config, load_dotenv};
+
+// ──────────────────────────────────────────────────────────────
+// CLI 定義
+// ──────────────────────────────────────────────────────────────
+
+/// s3d — Static 3D Asset Deployment CLI
+#[derive(Parser)]
+#[command(name = "s3d", version, about, long_about = None)]
+struct Cli {
+    /// s3d.config.json のパス（デフォルト: ./s3d.config.json）
+    #[arg(short, long, global = true, default_value = "s3d.config.json")]
+    config: PathBuf,
+
+    #[command(subcommand)]
+    command: Commands,
+}
+
+#[derive(Subcommand)]
+enum Commands {
+    /// プロジェクトを初期化する
+    Init,
+
+    /// アセットをビルドしてマニフェストを生成する
+    Build,
+
+    /// 2 つのマニフェストの差分を表示する
+    Diff {
+        /// 旧 manifest.json のパス（省略時は初回デプロイとして扱う）
+        #[arg(long)]
+        old: Option<PathBuf>,
+        /// 新 manifest.json のパス
+        new: PathBuf,
+    },
+
+    /// アセットを R2/S3 へアップロードする
+    Push {
+        /// manifest.json のパスを上書き指定
+        #[arg(long)]
+        manifest: Option<PathBuf>,
+        /// 実際の I/O を行わずプレビューのみ表示する
+        #[arg(long)]
+        dry_run: bool,
+    },
+
+    /// s3d.config.json と環境変数を検証する
+    Validate,
+}
+
+// ──────────────────────────────────────────────────────────────
+// main
+// ──────────────────────────────────────────────────────────────
+
+#[tokio::main]
+async fn main() {
+    if let Err(e) = run().await {
+        eprintln!("{} {e:#}", "error:".red().bold());
+        std::process::exit(1);
+    }
+}
+
+async fn run() -> Result<()> {
+    let cli = Cli::parse();
+
+    // .env をロード（ファイルがない場合は無視）
+    load_dotenv();
+
+    match cli.command {
+        Commands::Init => {
+            commands::init::run()?;
+        }
+
+        Commands::Build => {
+            let cfg = load_config(&cli.config)?;
+            commands::build::run(&cfg, &cli.config)?;
+        }
+
+        Commands::Diff { old, new } => {
+            commands::diff::run(old.as_deref(), &new)?;
+        }
+
+        Commands::Push { manifest, dry_run } => {
+            let cfg = load_config(&cli.config)?;
+            let storage = build_storage(&cfg)?;
+            commands::push::run(&cfg, &cli.config, manifest.as_deref(), dry_run, storage).await?;
+        }
+
+        Commands::Validate => {
+            commands::validate::run(&cli.config)?;
+        }
+    }
+
+    Ok(())
+}
+
+/// config から StoragePlugin を構築する
+fn build_storage(cfg: &config::S3dCliConfig) -> Result<Arc<dyn StoragePlugin>> {
+    use crate::config::CdnProvider;
+    use crate::storage::{credentials::StorageCredentials, r2::R2Storage};
+
+    let creds = StorageCredentials::from_env()?;
+    let bucket = cfg.storage.bucket.clone();
+
+    match cfg.storage.provider {
+        CdnProvider::CloudflareR2 => {
+            let account_id =
+                cfg.storage.account_id.as_deref().ok_or_else(|| {
+                    anyhow::anyhow!("storage.account_id が必要です (Cloudflare R2)")
+                })?;
+            let endpoint = cfg
+                .storage
+                .endpoint
+                .clone()
+                .unwrap_or_else(|| format!("https://{account_id}.r2.cloudflarestorage.com"));
+            let storage = R2Storage::new(creds, bucket, endpoint, None)?;
+            Ok(Arc::new(storage))
+        }
+        CdnProvider::AwsS3 | CdnProvider::Custom => {
+            let endpoint = cfg
+                .storage
+                .endpoint
+                .clone()
+                .ok_or_else(|| anyhow::anyhow!("storage.endpoint が必要です (Custom/S3)"))?;
+            let region = cfg.storage.region.clone();
+            let storage = R2Storage::new(creds, bucket, endpoint, region)?;
+            Ok(Arc::new(storage))
+        }
+    }
+}

--- a/crates/s3d-cli/src/storage/credentials.rs
+++ b/crates/s3d-cli/src/storage/credentials.rs
@@ -1,0 +1,39 @@
+//! 認証情報ヘルパー
+//!
+//! 環境変数 `S3D_ACCESS_KEY_ID` / `S3D_SECRET_ACCESS_KEY` を読み取る。
+
+use anyhow::{Context, Result};
+
+/// R2/S3 の認証情報
+#[derive(Debug, Clone)]
+pub struct StorageCredentials {
+    pub access_key_id: String,
+    pub secret_access_key: String,
+}
+
+impl StorageCredentials {
+    /// 環境変数から認証情報を読み込む
+    pub fn from_env() -> Result<Self> {
+        let access_key_id = std::env::var("S3D_ACCESS_KEY_ID")
+            .context("環境変数 S3D_ACCESS_KEY_ID が未設定です")?;
+        let secret_access_key = std::env::var("S3D_SECRET_ACCESS_KEY")
+            .context("環境変数 S3D_SECRET_ACCESS_KEY が未設定です")?;
+        Ok(Self {
+            access_key_id,
+            secret_access_key,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_from_env_missing() {
+        // Ensure vars are unset for this test
+        std::env::remove_var("S3D_ACCESS_KEY_ID");
+        std::env::remove_var("S3D_SECRET_ACCESS_KEY");
+        assert!(StorageCredentials::from_env().is_err());
+    }
+}

--- a/crates/s3d-cli/src/storage/mod.rs
+++ b/crates/s3d-cli/src/storage/mod.rs
@@ -1,0 +1,7 @@
+//! ストレージプラグイン — mod.rs
+
+pub mod credentials;
+pub mod r2;
+pub mod sign;
+
+pub use r2::R2Storage;

--- a/crates/s3d-cli/src/storage/r2.rs
+++ b/crates/s3d-cli/src/storage/r2.rs
@@ -1,0 +1,296 @@
+//! Cloudflare R2 / AWS S3 互換ストレージ実装
+//!
+//! `reqwest` と自前の AWS Signature V4 署名を使い、
+//! S3 互換エンドポイントへ接続する。
+//! 実際の接続が必要なテストは `#[ignore]` でスキップする。
+
+use anyhow::Result;
+use async_trait::async_trait;
+use reqwest::Client;
+use s3d_types::plugin::{StorageError, StoragePlugin, StorageResult};
+
+use crate::storage::credentials::StorageCredentials;
+use crate::storage::sign::{sign_request, SignConfig};
+
+// ──────────────────────────────────────────────────────────────
+// R2Storage
+// ──────────────────────────────────────────────────────────────
+
+/// Cloudflare R2 / S3 互換ストレージ
+pub struct R2Storage {
+    client: Client,
+    creds: StorageCredentials,
+    bucket: String,
+    endpoint: String,
+    region: String,
+}
+
+impl R2Storage {
+    /// 認証情報とエンドポイントから R2 クライアントを構築する
+    ///
+    /// `endpoint`: `https://<account_id>.r2.cloudflarestorage.com`
+    pub fn new(
+        creds: StorageCredentials,
+        bucket: String,
+        endpoint: String,
+        region: Option<String>,
+    ) -> Result<Self> {
+        let client = Client::builder()
+            .timeout(std::time::Duration::from_secs(60))
+            .build()?;
+        Ok(Self {
+            client,
+            creds,
+            bucket,
+            endpoint: endpoint.trim_end_matches('/').to_string(),
+            region: region.unwrap_or_else(|| "auto".to_string()),
+        })
+    }
+
+    fn url(&self, key: &str) -> String {
+        format!("{}/{}/{}", self.endpoint, self.bucket, key)
+    }
+
+    fn sign_cfg(
+        &self,
+        method: &str,
+        key: &str,
+        content_type: Option<&str>,
+        body: &[u8],
+    ) -> SignConfig {
+        SignConfig {
+            access_key: self.creds.access_key_id.clone(),
+            secret_key: self.creds.secret_access_key.clone(),
+            region: self.region.clone(),
+            service: "s3".to_string(),
+            method: method.to_string(),
+            bucket: self.bucket.clone(),
+            key: key.to_string(),
+            endpoint: self.endpoint.clone(),
+            content_type: content_type.map(|s| s.to_string()),
+            body: body.to_vec(),
+        }
+    }
+}
+
+// ──────────────────────────────────────────────────────────────
+// StoragePlugin impl
+// ──────────────────────────────────────────────────────────────
+
+#[async_trait]
+impl StoragePlugin for R2Storage {
+    async fn put(&self, key: &str, data: &[u8], content_type: &str) -> StorageResult<()> {
+        let url = self.url(key);
+        let sign_cfg = self.sign_cfg("PUT", key, Some(content_type), data);
+        let headers = sign_request(&sign_cfg).map_err(|e| StorageError {
+            message: format!("署名エラー: {e}"),
+            key: Some(key.into()),
+        })?;
+
+        let mut req = self.client.put(&url).body(data.to_vec());
+        for (k, v) in &headers {
+            req = req.header(k.as_str(), v.as_str());
+        }
+        let resp = req.send().await.map_err(|e| StorageError {
+            message: format!("PUT {key} failed: {e}"),
+            key: Some(key.into()),
+        })?;
+
+        if !resp.status().is_success() {
+            let status = resp.status();
+            let body = resp.text().await.unwrap_or_default();
+            return Err(StorageError {
+                message: format!("PUT {key} HTTP {status}: {body}"),
+                key: Some(key.into()),
+            });
+        }
+        Ok(())
+    }
+
+    async fn get(&self, key: &str) -> StorageResult<Vec<u8>> {
+        let url = self.url(key);
+        let sign_cfg = self.sign_cfg("GET", key, None, &[]);
+        let headers = sign_request(&sign_cfg).map_err(|e| StorageError {
+            message: format!("署名エラー: {e}"),
+            key: Some(key.into()),
+        })?;
+
+        let mut req = self.client.get(&url);
+        for (k, v) in &headers {
+            req = req.header(k.as_str(), v.as_str());
+        }
+        let resp = req.send().await.map_err(|e| StorageError {
+            message: format!("GET {key} failed: {e}"),
+            key: Some(key.into()),
+        })?;
+
+        if resp.status() == reqwest::StatusCode::NOT_FOUND {
+            return Err(StorageError {
+                message: format!("{key} not found"),
+                key: Some(key.into()),
+            });
+        }
+        if !resp.status().is_success() {
+            let status = resp.status();
+            let body = resp.text().await.unwrap_or_default();
+            return Err(StorageError {
+                message: format!("GET {key} HTTP {status}: {body}"),
+                key: Some(key.into()),
+            });
+        }
+        let bytes = resp.bytes().await.map_err(|e| StorageError {
+            message: format!("body read error for {key}: {e}"),
+            key: Some(key.into()),
+        })?;
+        Ok(bytes.to_vec())
+    }
+
+    async fn delete(&self, key: &str) -> StorageResult<()> {
+        let url = self.url(key);
+        let sign_cfg = self.sign_cfg("DELETE", key, None, &[]);
+        let headers = sign_request(&sign_cfg).map_err(|e| StorageError {
+            message: format!("署名エラー: {e}"),
+            key: Some(key.into()),
+        })?;
+
+        let mut req = self.client.delete(&url);
+        for (k, v) in &headers {
+            req = req.header(k.as_str(), v.as_str());
+        }
+        let resp = req.send().await.map_err(|e| StorageError {
+            message: format!("DELETE {key} failed: {e}"),
+            key: Some(key.into()),
+        })?;
+
+        if !resp.status().is_success() && resp.status() != reqwest::StatusCode::NO_CONTENT {
+            let status = resp.status();
+            let body = resp.text().await.unwrap_or_default();
+            return Err(StorageError {
+                message: format!("DELETE {key} HTTP {status}: {body}"),
+                key: Some(key.into()),
+            });
+        }
+        Ok(())
+    }
+
+    async fn list(&self, prefix: &str) -> StorageResult<Vec<String>> {
+        // list-objects-v2 クエリ
+        let query = format!("list-type=2&prefix={}", urlencoding_simple(prefix));
+        let url = format!("{}/?{}", self.url("").trim_end_matches('/'), query);
+
+        let sign_cfg = SignConfig {
+            access_key: self.creds.access_key_id.clone(),
+            secret_key: self.creds.secret_access_key.clone(),
+            region: self.region.clone(),
+            service: "s3".to_string(),
+            method: "GET".to_string(),
+            bucket: self.bucket.clone(),
+            key: "".to_string(),
+            endpoint: self.endpoint.clone(),
+            content_type: None,
+            body: vec![],
+        };
+        let headers = sign_request(&sign_cfg).map_err(|e| StorageError {
+            message: format!("署名エラー: {e}"),
+            key: None,
+        })?;
+
+        let mut req = self.client.get(&url);
+        for (k, v) in &headers {
+            req = req.header(k.as_str(), v.as_str());
+        }
+        let resp = req.send().await.map_err(|e| StorageError {
+            message: format!("LIST failed: {e}"),
+            key: None,
+        })?;
+
+        if !resp.status().is_success() {
+            let status = resp.status();
+            let body = resp.text().await.unwrap_or_default();
+            return Err(StorageError {
+                message: format!("LIST HTTP {status}: {body}"),
+                key: None,
+            });
+        }
+
+        let text = resp.text().await.map_err(|e| StorageError {
+            message: format!("body read error: {e}"),
+            key: None,
+        })?;
+
+        // 簡易 XML パース: <Key>...</Key> を抽出
+        let keys = extract_keys_from_xml(&text);
+        Ok(keys)
+    }
+}
+
+// ──────────────────────────────────────────────────────────────
+// Helpers
+// ──────────────────────────────────────────────────────────────
+
+fn urlencoding_simple(s: &str) -> String {
+    s.chars()
+        .map(|c| match c {
+            'A'..='Z' | 'a'..='z' | '0'..='9' | '-' | '_' | '.' | '~' | '/' => c.to_string(),
+            c => format!("%{:02X}", c as u32),
+        })
+        .collect()
+}
+
+fn extract_keys_from_xml(xml: &str) -> Vec<String> {
+    let mut keys = Vec::new();
+    let mut rest = xml;
+    while let Some(start) = rest.find("<Key>") {
+        rest = &rest[start + 5..];
+        if let Some(end) = rest.find("</Key>") {
+            keys.push(rest[..end].to_string());
+            rest = &rest[end + 6..];
+        } else {
+            break;
+        }
+    }
+    keys
+}
+
+// ──────────────────────────────────────────────────────────────
+// Tests
+// ──────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_extract_keys_from_xml() {
+        let xml = r#"<?xml version="1.0"?>
+<ListBucketResult>
+  <Contents><Key>app.js</Key></Contents>
+  <Contents><Key>style.css</Key></Contents>
+</ListBucketResult>"#;
+        let keys = extract_keys_from_xml(xml);
+        assert_eq!(keys, vec!["app.js", "style.css"]);
+    }
+
+    #[test]
+    fn test_urlencoding_simple() {
+        assert_eq!(urlencoding_simple("foo/bar.js"), "foo/bar.js");
+        assert_eq!(urlencoding_simple("foo bar"), "foo%20bar");
+    }
+
+    /// 実際の R2 エンドポイントが必要なテストは `#[ignore]`
+    #[tokio::test]
+    #[ignore]
+    async fn test_r2_put_get_delete() {
+        let creds = StorageCredentials::from_env().expect("creds");
+        let bucket = std::env::var("S3D_BUCKET").unwrap_or_else(|_| "test-bucket".to_string());
+        let endpoint = std::env::var("S3D_ENDPOINT")
+            .unwrap_or_else(|_| "https://example.r2.cloudflarestorage.com".to_string());
+        let storage = R2Storage::new(creds, bucket, endpoint, None).unwrap();
+
+        let key = "s3d-cli-test/hello.txt";
+        storage.put(key, b"hello", "text/plain").await.unwrap();
+        let data = storage.get(key).await.unwrap();
+        assert_eq!(data, b"hello");
+        storage.delete(key).await.unwrap();
+    }
+}

--- a/crates/s3d-cli/src/storage/sign.rs
+++ b/crates/s3d-cli/src/storage/sign.rs
@@ -1,0 +1,210 @@
+//! AWS Signature Version 4 署名ヘルパー
+//!
+//! PUT/GET/DELETE/LIST リクエストに必要な Authorization ヘッダーを生成する。
+
+use std::collections::BTreeMap;
+
+use anyhow::Result;
+use chrono::Utc;
+use hmac::{Hmac, Mac};
+use sha2::{Digest, Sha256};
+
+type HmacSha256 = Hmac<Sha256>;
+
+/// 署名設定
+pub struct SignConfig {
+    pub access_key: String,
+    pub secret_key: String,
+    pub region: String,
+    pub service: String,
+    pub method: String,
+    pub bucket: String,
+    pub key: String,
+    pub endpoint: String,
+    pub content_type: Option<String>,
+    pub body: Vec<u8>,
+}
+
+/// リクエストに付与するヘッダーマップを返す
+pub fn sign_request(cfg: &SignConfig) -> Result<BTreeMap<String, String>> {
+    let now = Utc::now();
+    let date_stamp = now.format("%Y%m%d").to_string(); // 20260101
+    let amz_date = now.format("%Y%m%dT%H%M%SZ").to_string(); // 20260101T120000Z
+
+    // ── ペイロードハッシュ
+    let payload_hash = hex_sha256(&cfg.body);
+
+    // ── Canonical URI
+    let uri = if cfg.key.is_empty() {
+        format!("/{}/", cfg.bucket)
+    } else {
+        format!("/{}/{}", cfg.bucket, encode_uri(&cfg.key))
+    };
+
+    // ── Canonical Query String (list 時は呼び出し元が URL に付与済み)
+    let canonical_qs = "".to_string();
+
+    // ── ホスト
+    let host = extract_host(&cfg.endpoint);
+
+    // ── 署名対象ヘッダー
+    let mut signed_headers_map: BTreeMap<String, String> = BTreeMap::new();
+    signed_headers_map.insert("host".to_string(), host.clone());
+    signed_headers_map.insert("x-amz-content-sha256".to_string(), payload_hash.clone());
+    signed_headers_map.insert("x-amz-date".to_string(), amz_date.clone());
+    if let Some(ct) = &cfg.content_type {
+        signed_headers_map.insert("content-type".to_string(), ct.clone());
+    }
+
+    let signed_headers_str: String = signed_headers_map
+        .keys()
+        .cloned()
+        .collect::<Vec<_>>()
+        .join(";");
+
+    let canonical_headers: String = signed_headers_map
+        .iter()
+        .map(|(k, v)| format!("{k}:{v}\n"))
+        .collect();
+
+    // ── Canonical Request
+    let canonical_request = format!(
+        "{method}\n{uri}\n{qs}\n{headers}\n{signed_headers}\n{payload}",
+        method = cfg.method,
+        uri = uri,
+        qs = canonical_qs,
+        headers = canonical_headers,
+        signed_headers = signed_headers_str,
+        payload = payload_hash,
+    );
+
+    // ── String To Sign
+    let scope = format!(
+        "{date_stamp}/{region}/{service}/aws4_request",
+        region = cfg.region,
+        service = cfg.service
+    );
+    let string_to_sign = format!(
+        "AWS4-HMAC-SHA256\n{amz_date}\n{scope}\n{cr_hash}",
+        cr_hash = hex_sha256(canonical_request.as_bytes()),
+    );
+
+    // ── 署名鍵
+    let signing_key = derive_signing_key(&cfg.secret_key, &date_stamp, &cfg.region, &cfg.service)?;
+    let signature = hmac_sha256_hex(&signing_key, string_to_sign.as_bytes())?;
+
+    // ── Authorization ヘッダー
+    let authorization = format!(
+        "AWS4-HMAC-SHA256 Credential={access_key}/{scope}, SignedHeaders={signed_headers}, Signature={sig}",
+        access_key = cfg.access_key,
+        scope = scope,
+        signed_headers = signed_headers_str,
+        sig = signature,
+    );
+
+    let mut headers: BTreeMap<String, String> = BTreeMap::new();
+    headers.insert("Authorization".to_string(), authorization);
+    headers.insert("x-amz-date".to_string(), amz_date);
+    headers.insert("x-amz-content-sha256".to_string(), payload_hash);
+    headers.insert("Host".to_string(), host);
+    if let Some(ct) = &cfg.content_type {
+        headers.insert("Content-Type".to_string(), ct.clone());
+    }
+
+    Ok(headers)
+}
+
+// ──────────────────────────────────────────────────────────────
+// Helpers
+// ──────────────────────────────────────────────────────────────
+
+fn hex_sha256(data: &[u8]) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(data);
+    hex::encode(hasher.finalize())
+}
+
+fn hmac_sha256_hex(key: &[u8], data: &[u8]) -> Result<String> {
+    let mut mac = HmacSha256::new_from_slice(key)?;
+    mac.update(data);
+    Ok(hex::encode(mac.finalize().into_bytes()))
+}
+
+fn hmac_sha256_raw(key: &[u8], data: &[u8]) -> Result<Vec<u8>> {
+    let mut mac = HmacSha256::new_from_slice(key)?;
+    mac.update(data);
+    Ok(mac.finalize().into_bytes().to_vec())
+}
+
+fn derive_signing_key(secret: &str, date: &str, region: &str, service: &str) -> Result<Vec<u8>> {
+    let k_date = hmac_sha256_raw(format!("AWS4{secret}").as_bytes(), date.as_bytes())?;
+    let k_region = hmac_sha256_raw(&k_date, region.as_bytes())?;
+    let k_service = hmac_sha256_raw(&k_region, service.as_bytes())?;
+    let k_signing = hmac_sha256_raw(&k_service, b"aws4_request")?;
+    Ok(k_signing)
+}
+
+fn extract_host(endpoint: &str) -> String {
+    endpoint
+        .trim_start_matches("https://")
+        .trim_start_matches("http://")
+        .trim_end_matches('/')
+        .to_string()
+}
+
+/// URI エンコード（スラッシュはエンコードしない）
+fn encode_uri(s: &str) -> String {
+    s.chars()
+        .map(|c| match c {
+            'A'..='Z' | 'a'..='z' | '0'..='9' | '-' | '_' | '.' | '~' | '/' => c.to_string(),
+            c => format!("%{:02X}", c as u32),
+        })
+        .collect()
+}
+
+// ──────────────────────────────────────────────────────────────
+// Tests
+// ──────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_hex_sha256_empty() {
+        // SHA-256 of empty string
+        assert_eq!(
+            hex_sha256(b""),
+            "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+        );
+    }
+
+    #[test]
+    fn test_extract_host() {
+        assert_eq!(
+            extract_host("https://abc123.r2.cloudflarestorage.com"),
+            "abc123.r2.cloudflarestorage.com"
+        );
+        assert_eq!(extract_host("http://localhost:9000/"), "localhost:9000");
+    }
+
+    #[test]
+    fn test_sign_request_returns_headers() {
+        let cfg = SignConfig {
+            access_key: "AKID".to_string(),
+            secret_key: "SECRET".to_string(),
+            region: "auto".to_string(),
+            service: "s3".to_string(),
+            method: "PUT".to_string(),
+            bucket: "my-bucket".to_string(),
+            key: "app.js".to_string(),
+            endpoint: "https://example.r2.cloudflarestorage.com".to_string(),
+            content_type: Some("application/javascript".to_string()),
+            body: b"console.log(1)".to_vec(),
+        };
+        let headers = sign_request(&cfg).unwrap();
+        assert!(headers.contains_key("Authorization"));
+        assert!(headers.contains_key("x-amz-date"));
+        assert!(headers.contains_key("x-amz-content-sha256"));
+    }
+}


### PR DESCRIPTION
## 概要

Issue #12 の実装。s3d CLI バイナリ `crates/s3d-cli` の初期実装。

> **Note:** Rust 1.85 環境のため `aws-sdk-s3` (requires rustc 1.91.1) の代わりに `reqwest` + AWS Signature V4 自前実装を採用。

---

## 追加ファイル

### `crates/s3d-cli/`

| ファイル | 内容 |
|---|---|
| `Cargo.toml` | 依存: s3d-types, s3d-deploy, clap, colored, reqwest, hmac/sha2, dotenvy, dialoguer, chrono |
| `src/main.rs` | clap Subcommand CLI エントリポイント (`s3d init/build/diff/push/validate`) |
| `src/config.rs` | `S3dCliConfig` / `StorageConfig` / `.env` ロード / 検証 |
| `src/commands/init.rs` | `s3d init` — インタラクティブプロンプト → `s3d.config.json`/`.env.example`/`.gitignore`/`output/` 生成 |
| `src/commands/build.rs` | `s3d build` — collect → hash_assets → build_manifest → `manifest.json` 書き込み・サマリ表示 |
| `src/commands/diff.rs` | `s3d diff` — 2 マニフェスト比較 (Added/Modified/Deleted/Unchanged カラー表示) |
| `src/commands/push.rs` | `s3d push` — 旧 manifest 取得 → diff → 並列アップロード → 削除 / `--dry-run` 対応 |
| `src/commands/validate.rs` | `s3d validate` — config + 環境変数チェック |
| `src/storage/credentials.rs` | `StorageCredentials::from_env()` |
| `src/storage/r2.rs` | `R2Storage` — reqwest ベース S3 互換 PUT/GET/DELETE/LIST |
| `src/storage/sign.rs` | AWS Signature V4 署名実装 (HMAC-SHA256) |

### ルート

| ファイル | 内容 |
|---|---|
| `README.md` | クレート一覧・アーキテクチャ・クイックスタート |
| `.env.example` | `S3D_ACCESS_KEY_ID` / `S3D_SECRET_ACCESS_KEY` テンプレート |
| `.gitignore` | `.env` を追加 |

---

## テスト結果

```
cargo test -p s3d-cli
→ 20 passed, 0 failed, 1 ignored
```

| テストグループ | 内容 |
|---|---|
| `config` | 読み書き・パス解決・バリデーション |
| `commands::build` | manifest.json 生成確認 |
| `commands::diff` | カラー差分表示・ファイル比較 |
| `commands::push` | dry-run・変更なし検出 (MockStorage) |
| `commands::validate` | missing config・valid config |
| `storage::sign` | Signature V4 ヘッダー生成・SHA256 |
| `storage::r2` | XML パース・URL エンコード |
| R2 実接続テスト | `#[ignore]` (CI 不要) |