### PR TITLE
feat(s3d-cli): scaffold src/, Cloudflare env vars, strategy.json validation — Closes #14

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,3 @@
-S3D_ACCESS_KEY_ID=your_access_key_id
-S3D_SECRET_ACCESS_KEY=your_secret_access_key
+CLOUDFLARE_ACCOUNT_ID=your_cloudflare_account_id
+CLOUDFLARE_R2_ACCESS_KEY_ID=your_r2_access_key_id
+CLOUDFLARE_R2_SECRET_ACCESS_KEY=your_r2_secret_access_key

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 .env
+output/

--- a/README.md
+++ b/README.md
@@ -15,43 +15,113 @@
 ## アーキテクチャ
 
 ```
-[output/]  ─→  s3d-deploy  ─→  manifest.json
-                   │
-                   ▼
-              s3d-cli push  ─→  Cloudflare R2 / AWS S3
-                   │
-                   ▼
-           s3d-loader (browser)  ─→  assetsStrategy / strategyAssets
-                   │
-                   ▼
-           s3d-display  ─→  HTML + iframe 正規化
+[src/]  ─→  s3d build  ─→  [output/]  ─→  s3d push  ─→  Cloudflare R2 / AWS S3
+                                 │
+                                 ▼
+                         manifest.json
+                                 │
+                         s3d-loader (browser)
+                                 │
+                         assetsStrategy / strategyAssets
 ```
 
-## クイックスタート
+## 開発者体験 — プロジェクト作成から配信まで
 
 ```bash
+mkdir my-service
+cd my-service
+
 # 1. プロジェクト初期化（インタラクティブ）
 s3d init
 
 # 2. .env に認証情報を記入
 cp .env.example .env
-# S3D_ACCESS_KEY_ID / S3D_SECRET_ACCESS_KEY を設定
+# CLOUDFLARE_R2_ACCESS_KEY_ID / CLOUDFLARE_R2_SECRET_ACCESS_KEY を設定
 
-# 3. アセットを output/ に配置
-cp -r dist/ output/
+# 3. src/ にファイルを配置
+#    （s3d init で src/index.html, src/assets/, src/assetsStrategy/strategy.json が生成済み）
 
-# 4. ビルド（マニフェスト生成）
+# 4. ビルド（マニフェスト生成 + ハッシュ付きファイルを output/ にコピー）
 s3d build
 
-# 5. 差分確認（オプション）
-s3d diff --old old-manifest.json output/manifest.json
-
-# 6. R2/S3 へアップロード
+# 5. R2/S3 へアップロード
 s3d push
 
-# 7. ドライラン（実際にはアップロードしない）
-s3d push --dry-run
+# → R2 で配信完了 🎉
 ```
+
+### `s3d init` 後のディレクトリ構成
+
+```
+my-service/
+├─ s3d.config.json
+├─ .env.example
+├─ .gitignore                  (/target, .env, output/ を含む)
+├─ src/
+│   ├─ index.html              ← スキャフォールドテンプレート
+│   ├─ assetsStrategy/
+│   │   └─ strategy.json       ← 配信戦略の定義
+│   └─ assets/                 ← 自由に配置
+│       ├─ style.css
+│       ├─ main.js
+│       ├─ hero.png
+│       └─ models/
+│           └─ shop.glb
+└─ output/                     ← s3d build の出力（自動生成、.gitignore 済み）
+    ├─ manifest.json
+    └─ ...
+```
+
+### アセット配信の 2 つの方法
+
+**SEO 対象ファイル（クローラに読ませる）:**
+
+```html
+<img src="assets/hero.png" alt="hero" />
+<link rel="stylesheet" href="assets/style.css" />
+```
+
+**SEO 不要の重いアセット（クローラはスキップ、CDN から非同期取得）:**
+
+```html
+<script type="module">
+  const { strategyAssets } = await import('./assetsStrategy/loader.js');
+  const assets = await strategyAssets();
+  // assets.get('assets/models/shop.glb') → CDN URL
+</script>
+```
+
+### `src/assetsStrategy/strategy.json` の例
+
+```json
+{
+  "initial": {
+    "sources": ["assets/style.css", "assets/main.js", "assets/hero.png"],
+    "cache": true
+  },
+  "cdn": {
+    "files": ["assets/models/**", "assets/detail-*.png"],
+    "cache": true,
+    "maxAge": "7d"
+  },
+  "reload": {
+    "trigger": "manifest-change",
+    "strategy": "diff"
+  }
+}
+```
+
+ファイル配置は自由。戦略側で「最初に送るもの」「後から送るもの」を宣言します。
+
+## CLI コマンド
+
+| コマンド | 説明 |
+|---|---|
+| `s3d init` | インタラクティブにプロジェクトを初期化 |
+| `s3d build` | `src/` を収集・ハッシュ化し `output/` にビルド |
+| `s3d diff --old old.json new.json` | 2 つのマニフェストを比較・表示 |
+| `s3d push [--dry-run]` | `output/` を R2/S3 へアップロード |
+| `s3d validate` | `s3d.config.json` / `strategy.json` / 環境変数を検証 |
 
 ## s3d.config.json
 
@@ -64,9 +134,8 @@ s3d push --dry-run
     "cdn_base_url": "https://cdn.example.com",
     "account_id": "your_cloudflare_account_id"
   },
-  "output_dir": "output",
-  "include": [],
-  "exclude": ["**/.DS_Store"]
+  "src_dir": "src",
+  "output_dir": "output"
 }
 ```
 
@@ -74,8 +143,11 @@ s3d push --dry-run
 
 | 変数名 | 説明 |
 |---|---|
-| `S3D_ACCESS_KEY_ID` | R2/S3 アクセスキー ID |
-| `S3D_SECRET_ACCESS_KEY` | R2/S3 シークレットアクセスキー |
+| `CLOUDFLARE_ACCOUNT_ID` | Cloudflare アカウント ID |
+| `CLOUDFLARE_R2_ACCESS_KEY_ID` | R2 アクセスキー ID |
+| `CLOUDFLARE_R2_SECRET_ACCESS_KEY` | R2 シークレットアクセスキー |
+| `S3D_ACCESS_KEY_ID` | 汎用アクセスキー（フォールバック） |
+| `S3D_SECRET_ACCESS_KEY` | 汎用シークレットキー（フォールバック） |
 
 ## ビルド
 
@@ -86,7 +158,7 @@ cargo build
 # テスト
 cargo test
 
-# CLI バイナリのビルド
+# CLI バイナリのビルド (release)
 cargo build -p s3d-cli --release
 ```
 

--- a/crates/s3d-cli/src/commands/build.rs
+++ b/crates/s3d-cli/src/commands/build.rs
@@ -1,4 +1,7 @@
 //! `s3d build` — アセット収集・ハッシュ化・マニフェスト生成コマンド
+//!
+//! `src/` を読み取り、ハッシュ付きファイルを `output/` にコピーして
+//! `output/manifest.json` を生成する。
 
 use std::path::Path;
 use std::time::Instant;
@@ -17,10 +20,19 @@ use crate::config::S3dCliConfig;
 pub fn run(config: &S3dCliConfig, config_path: &Path) -> Result<()> {
     let start = Instant::now();
     let project_root = config_path.parent().unwrap_or(Path::new("."));
+    let src_dir = project_root.join(&config.src_dir);
     let output_dir = project_root.join(&config.output_dir);
 
     println!("{}", "s3d build — アセットをビルドします".bold().cyan());
-    println!("  入力ディレクトリ : {}", output_dir.display());
+    println!("  ソースディレクトリ : {}", src_dir.display());
+    println!("  出力ディレクトリ   : {}", output_dir.display());
+
+    if !src_dir.exists() {
+        anyhow::bail!(
+            "ソースディレクトリが見つかりません: {}\n`s3d init` を実行して src/ を生成してください。",
+            src_dir.display()
+        );
+    }
 
     // ── 1. 収集
     let collect_opts = CollectOptions {
@@ -28,15 +40,32 @@ pub fn run(config: &S3dCliConfig, config_path: &Path) -> Result<()> {
         include: config.include.clone(),
         max_file_size: config.max_file_size.clone(),
     };
-    let collected = collect(&output_dir, &collect_opts)
-        .with_context(|| format!("アセット収集エラー: {}", output_dir.display()))?;
+    let collected = collect(&src_dir, &collect_opts)
+        .with_context(|| format!("アセット収集エラー: {}", src_dir.display()))?;
     println!("  収集: {} ファイル", collected.len().to_string().bold());
 
     // ── 2. ハッシュ化
     let hashed = hash_assets(&collected, s3d_deploy::hash::DEFAULT_HASH_LENGTH)
         .context("ハッシュ計算エラー")?;
 
-    // ── 3. マニフェスト生成
+    // ── 3. output/ へハッシュ付きファイルをコピー
+    std::fs::create_dir_all(&output_dir)?;
+    for asset in &hashed {
+        // hashed_key は "assets/style.abcd1234.css" のような形式
+        let dest = output_dir.join(&asset.hashed_key);
+        if let Some(parent) = dest.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        std::fs::copy(&asset.absolute_path, &dest).with_context(|| {
+            format!(
+                "ファイルコピー失敗: {} → {}",
+                asset.absolute_path.display(),
+                dest.display()
+            )
+        })?;
+    }
+
+    // ── 4. マニフェスト生成
     let manifest_opts = ManifestOptions {
         cdn_base_url: config
             .storage
@@ -48,7 +77,7 @@ pub fn run(config: &S3dCliConfig, config_path: &Path) -> Result<()> {
     };
     let manifest = build_manifest(&hashed, &manifest_opts).context("マニフェスト生成エラー")?;
 
-    // ── 4. manifest.json の書き込み
+    // ── 5. manifest.json の書き込み
     let manifest_path = config.resolved_manifest_path();
     let manifest_path = if manifest_path.is_absolute() {
         manifest_path
@@ -78,7 +107,7 @@ pub fn run(config: &S3dCliConfig, config_path: &Path) -> Result<()> {
     Ok(())
 }
 
-fn format_bytes(bytes: u64) -> String {
+pub fn format_bytes(bytes: u64) -> String {
     if bytes >= 1_073_741_824 {
         format!("{:.2} GB", bytes as f64 / 1_073_741_824.0)
     } else if bytes >= 1_048_576 {
@@ -100,7 +129,7 @@ mod tests {
     use crate::config::{CdnProvider, S3dCliConfig, StorageConfig};
     use tempfile::TempDir;
 
-    fn make_config(output_dir: &str) -> S3dCliConfig {
+    fn make_config(src_dir: &str) -> S3dCliConfig {
         S3dCliConfig {
             project: "test".to_string(),
             storage: StorageConfig {
@@ -111,7 +140,8 @@ mod tests {
                 endpoint: None,
                 region: None,
             },
-            output_dir: output_dir.to_string(),
+            src_dir: src_dir.to_string(),
+            output_dir: "output".to_string(),
             include: vec![],
             exclude: vec![],
             max_file_size: None,
@@ -120,27 +150,60 @@ mod tests {
     }
 
     #[test]
-    fn test_build_creates_manifest() {
+    fn test_build_creates_manifest_and_hashed_files() {
         let dir = TempDir::new().unwrap();
-        let output = dir.path().join("output");
-        std::fs::create_dir_all(&output).unwrap();
-        // ダミーアセット
-        std::fs::write(output.join("app.js"), b"console.log('hello');").unwrap();
-        std::fs::write(output.join("style.css"), b"body { margin: 0; }").unwrap();
+        let src = dir.path().join("src");
+        std::fs::create_dir_all(&src).unwrap();
+        std::fs::write(src.join("app.js"), b"console.log('hello');").unwrap();
+        std::fs::write(src.join("style.css"), b"body { margin: 0; }").unwrap();
 
         let config_path = dir.path().join("s3d.config.json");
-        let cfg = make_config("output");
+        let cfg = make_config("src");
         crate::config::save_config(&config_path, &cfg).unwrap();
 
         run(&cfg, &config_path).unwrap();
 
+        // manifest.json が生成されている
         let manifest_path = dir.path().join("output/manifest.json");
         assert!(manifest_path.exists(), "manifest.json が生成されていない");
+
+        // マニフェストの内容確認
         let content = std::fs::read_to_string(&manifest_path).unwrap();
+        let v: serde_json::Value = serde_json::from_str(&content).unwrap();
+        let assets = v["assets"].as_object().unwrap();
+        // 元のキー（app.js / style.css）がマニフェストキーになっている
         assert!(
-            content.contains("app.js") || content.contains("app."),
-            "app.js がマニフェストに含まれていない"
+            assets.contains_key("app.js"),
+            "app.js がマニフェストに含まれていない: {content}"
         );
+        assert!(
+            assets.contains_key("style.css"),
+            "style.css が含まれていない"
+        );
+
+        // output/ にハッシュ付きファイルがコピーされている
+        let output_files: Vec<_> = std::fs::read_dir(dir.path().join("output"))
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .map(|e| e.file_name().to_string_lossy().to_string())
+            .collect();
+        // app.abcd1234.js のような形式のファイルが存在する
+        assert!(
+            output_files
+                .iter()
+                .any(|f| f.contains("app") && f.ends_with(".js")),
+            "ハッシュ付き app.js が output/ に存在しない: {output_files:?}"
+        );
+    }
+
+    #[test]
+    fn test_build_src_not_found() {
+        let dir = TempDir::new().unwrap();
+        // src/ を作らない
+        let config_path = dir.path().join("s3d.config.json");
+        let cfg = make_config("src");
+        crate::config::save_config(&config_path, &cfg).unwrap();
+        assert!(run(&cfg, &config_path).is_err());
     }
 
     #[test]

--- a/crates/s3d-cli/src/commands/init.rs
+++ b/crates/s3d-cli/src/commands/init.rs
@@ -1,7 +1,13 @@
 //! `s3d init` — プロジェクト初期化コマンド
 //!
-//! インタラクティブなプロンプトで設定を収集し
-//! `s3d.config.json`, `.env.example`, `.gitignore`, `output/` を生成する。
+//! インタラクティブなプロンプトで設定を収集し、以下を生成する:
+//! - `s3d.config.json`
+//! - `.env.example`
+//! - `.gitignore`
+//! - `src/index.html`                         (スキャフォールド HTML)
+//! - `src/assetsStrategy/strategy.json`       (デフォルト配信戦略)
+//! - `src/assets/.gitkeep`                    (空ディレクトリ保持)
+//! - `output/`                                (ビルド出力先)
 
 use anyhow::Result;
 use colored::Colorize;
@@ -72,13 +78,14 @@ pub fn run() -> Result<()> {
     let config = S3dCliConfig {
         project: project.clone(),
         storage: StorageConfig {
-            provider,
+            provider: provider.clone(),
             bucket,
             cdn_base_url,
             account_id,
             endpoint: None,
             region,
         },
+        src_dir: "src".to_string(),
         output_dir: "output".to_string(),
         include: vec![],
         exclude: vec![],
@@ -90,31 +97,16 @@ pub fn run() -> Result<()> {
     println!("{}", "✔ s3d.config.json を生成しました".green());
 
     // ── .env.example
-    std::fs::write(
-        ".env.example",
-        "S3D_ACCESS_KEY_ID=your_access_key_id\n\
-         S3D_SECRET_ACCESS_KEY=your_secret_access_key\n",
-    )?;
+    write_env_example(&provider)?;
     println!("{}", "✔ .env.example を生成しました".green());
 
     // ── .gitignore
-    let gitignore_path = std::path::Path::new(".gitignore");
-    let mut gitignore_content = if gitignore_path.exists() {
-        std::fs::read_to_string(gitignore_path)?
-    } else {
-        String::new()
-    };
-    for entry in ["/target", ".env"] {
-        if !gitignore_content.contains(entry) {
-            if !gitignore_content.ends_with('\n') && !gitignore_content.is_empty() {
-                gitignore_content.push('\n');
-            }
-            gitignore_content.push_str(entry);
-            gitignore_content.push('\n');
-        }
-    }
-    std::fs::write(".gitignore", &gitignore_content)?;
+    write_gitignore()?;
     println!("{}", "✔ .gitignore を更新しました".green());
+
+    // ── src/ スキャフォールド
+    scaffold_src(&project)?;
+    println!("{}", "✔ src/ を生成しました".green());
 
     // ── output/ ディレクトリ
     std::fs::create_dir_all("output")?;
@@ -122,10 +114,111 @@ pub fn run() -> Result<()> {
 
     println!();
     println!("{}", "次のステップ:".bold());
-    println!("  1. cp .env.example .env  # R2/S3 の認証情報を記入");
-    println!("  2. アセットを output/ に配置");
+    println!("  1. cp .env.example .env  # 認証情報を記入");
+    println!("  2. src/ にファイルを配置");
     println!("  3. s3d build              # マニフェスト生成");
     println!("  4. s3d push               # R2/S3 へアップロード");
+
+    Ok(())
+}
+
+// ──────────────────────────────────────────────────────────────
+// Scaffold helpers
+// ──────────────────────────────────────────────────────────────
+
+fn write_env_example(provider: &CdnProvider) -> Result<()> {
+    let content = match provider {
+        CdnProvider::CloudflareR2 => {
+            "CLOUDFLARE_ACCOUNT_ID=your_cloudflare_account_id\n\
+             CLOUDFLARE_R2_ACCESS_KEY_ID=your_r2_access_key_id\n\
+             CLOUDFLARE_R2_SECRET_ACCESS_KEY=your_r2_secret_access_key\n"
+        }
+        CdnProvider::AwsS3 | CdnProvider::Custom => {
+            "S3D_ACCESS_KEY_ID=your_access_key_id\n\
+             S3D_SECRET_ACCESS_KEY=your_secret_access_key\n"
+        }
+    };
+    std::fs::write(".env.example", content)?;
+    Ok(())
+}
+
+fn write_gitignore() -> Result<()> {
+    let path = std::path::Path::new(".gitignore");
+    let mut content = if path.exists() {
+        std::fs::read_to_string(path)?
+    } else {
+        String::new()
+    };
+    for entry in ["/target", ".env", "output/"] {
+        if !content.contains(entry) {
+            if !content.ends_with('\n') && !content.is_empty() {
+                content.push('\n');
+            }
+            content.push_str(entry);
+            content.push('\n');
+        }
+    }
+    std::fs::write(path, &content)?;
+    Ok(())
+}
+
+fn scaffold_src(project: &str) -> Result<()> {
+    // src/assets/.gitkeep
+    std::fs::create_dir_all("src/assets")?;
+    std::fs::write("src/assets/.gitkeep", "")?;
+
+    // src/assetsStrategy/strategy.json
+    std::fs::create_dir_all("src/assetsStrategy")?;
+    let strategy_json = r#"{
+  "initial": {
+    "sources": ["assets/style.css", "assets/main.js", "assets/hero.png"],
+    "cache": true
+  },
+  "cdn": {
+    "files": ["assets/models/**", "assets/detail-*.png"],
+    "cache": true,
+    "maxAge": "7d"
+  },
+  "reload": {
+    "trigger": "manifest-change",
+    "strategy": "diff"
+  }
+}
+"#;
+    std::fs::write("src/assetsStrategy/strategy.json", strategy_json)?;
+
+    // src/index.html
+    let index_html = format!(
+        r#"<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>{project}</title>
+  <link rel="stylesheet" href="assets/style.css" />
+</head>
+<body>
+  <h1>{project}</h1>
+
+  <!--
+    SEO 対象のアセットは直接 <img>/<link> で参照する:
+    <img src="assets/hero.png" alt="hero" />
+
+    SEO 不要の重いアセットは strategyAssets() で非同期取得する:
+    <script type="module">
+      const {{ strategyAssets }} = await import('./assetsStrategy/loader.js');
+      const assets = await strategyAssets();
+      // assets.get('assets/models/shop.glb') → CDN URL
+    </script>
+  -->
+
+  <script src="assets/main.js"></script>
+</body>
+</html>
+"#,
+        project = project
+    );
+    std::fs::write("src/index.html", &index_html)?;
 
     Ok(())
 }
@@ -139,23 +232,22 @@ mod tests {
     use crate::config::{load_config, save_config, CdnProvider, S3dCliConfig, StorageConfig};
     use tempfile::TempDir;
 
-    /// init が生成するファイルのテスト（プロンプトなしで直接生成）
-    #[test]
-    fn test_generate_files() {
+    fn make_and_scaffold(project: &str, provider: CdnProvider) -> TempDir {
         let dir = TempDir::new().unwrap();
         let orig = std::env::current_dir().unwrap();
         std::env::set_current_dir(dir.path()).unwrap();
 
         let config = S3dCliConfig {
-            project: "test-project".to_string(),
+            project: project.to_string(),
             storage: StorageConfig {
-                provider: CdnProvider::CloudflareR2,
+                provider: provider.clone(),
                 bucket: "test-bucket".to_string(),
                 cdn_base_url: "https://cdn.example.com".to_string(),
                 account_id: Some("acc123".to_string()),
                 endpoint: None,
                 region: None,
             },
+            src_dir: "src".to_string(),
             output_dir: "output".to_string(),
             include: vec![],
             exclude: vec![],
@@ -163,24 +255,73 @@ mod tests {
             manifest_path: None,
         };
         save_config(std::path::Path::new("s3d.config.json"), &config).unwrap();
-
-        // .env.example
-        std::fs::write(
-            ".env.example",
-            "S3D_ACCESS_KEY_ID=your_access_key_id\nS3D_SECRET_ACCESS_KEY=your_secret_access_key\n",
-        )
-        .unwrap();
-
-        // output/
+        super::write_env_example(&provider).unwrap();
+        super::write_gitignore().unwrap();
+        super::scaffold_src(project).unwrap();
         std::fs::create_dir_all("output").unwrap();
 
-        assert!(std::path::Path::new("s3d.config.json").exists());
-        assert!(std::path::Path::new(".env.example").exists());
-        assert!(std::path::Path::new("output").is_dir());
-
-        let loaded = load_config(std::path::Path::new("s3d.config.json")).unwrap();
-        assert_eq!(loaded.project, "test-project");
-
         std::env::set_current_dir(&orig).unwrap();
+        dir
+    }
+
+    #[test]
+    fn test_generate_config_file() {
+        let dir = make_and_scaffold("test-project", CdnProvider::CloudflareR2);
+        let loaded = load_config(&dir.path().join("s3d.config.json")).unwrap();
+        assert_eq!(loaded.project, "test-project");
+        assert_eq!(loaded.src_dir, "src");
+        assert_eq!(loaded.output_dir, "output");
+    }
+
+    #[test]
+    fn test_scaffold_src_structure() {
+        let dir = make_and_scaffold("myapp", CdnProvider::CloudflareR2);
+        // ディレクトリ
+        assert!(dir.path().join("src").is_dir());
+        assert!(dir.path().join("src/assets").is_dir());
+        assert!(dir.path().join("src/assetsStrategy").is_dir());
+        assert!(dir.path().join("output").is_dir());
+        // ファイル
+        assert!(dir.path().join("src/index.html").exists());
+        assert!(dir.path().join("src/assetsStrategy/strategy.json").exists());
+        assert!(dir.path().join("src/assets/.gitkeep").exists());
+        assert!(dir.path().join(".env.example").exists());
+        assert!(dir.path().join(".gitignore").exists());
+    }
+
+    #[test]
+    fn test_index_html_contains_project_name() {
+        let dir = make_and_scaffold("MyShop3D", CdnProvider::CloudflareR2);
+        let html = std::fs::read_to_string(dir.path().join("src/index.html")).unwrap();
+        assert!(html.contains("MyShop3D"));
+    }
+
+    #[test]
+    fn test_strategy_json_valid() {
+        let dir = make_and_scaffold("proj", CdnProvider::CloudflareR2);
+        let content =
+            std::fs::read_to_string(dir.path().join("src/assetsStrategy/strategy.json")).unwrap();
+        let v: serde_json::Value = serde_json::from_str(&content).unwrap();
+        assert!(v.get("initial").is_some());
+        assert!(v.get("cdn").is_some());
+        assert!(v.get("reload").is_some());
+    }
+
+    #[test]
+    fn test_env_example_cloudflare() {
+        let dir = make_and_scaffold("proj", CdnProvider::CloudflareR2);
+        let content = std::fs::read_to_string(dir.path().join(".env.example")).unwrap();
+        assert!(content.contains("CLOUDFLARE_R2_ACCESS_KEY_ID"));
+        assert!(content.contains("CLOUDFLARE_R2_SECRET_ACCESS_KEY"));
+        assert!(content.contains("CLOUDFLARE_ACCOUNT_ID"));
+    }
+
+    #[test]
+    fn test_gitignore_contains_output() {
+        let dir = make_and_scaffold("proj", CdnProvider::CloudflareR2);
+        let content = std::fs::read_to_string(dir.path().join(".gitignore")).unwrap();
+        assert!(content.contains("output/"));
+        assert!(content.contains(".env"));
+        assert!(content.contains("/target"));
     }
 }

--- a/crates/s3d-cli/src/commands/push.rs
+++ b/crates/s3d-cli/src/commands/push.rs
@@ -241,6 +241,7 @@ mod tests {
                 endpoint: None,
                 region: None,
             },
+            src_dir: "src".to_string(),
             output_dir: "output".to_string(),
             include: vec![],
             exclude: vec![],

--- a/crates/s3d-cli/src/commands/validate.rs
+++ b/crates/s3d-cli/src/commands/validate.rs
@@ -1,4 +1,4 @@
-//! `s3d validate` — s3d.config.json と .env の検証コマンド
+//! `s3d validate` — s3d.config.json / strategy.json / .env の検証コマンド
 
 use std::path::Path;
 
@@ -11,7 +11,7 @@ use crate::config::{load_config, validate_config_and_env, S3dCliConfig};
 pub fn run(config_path: &Path) -> Result<()> {
     println!("{}", "s3d validate — 設定の検証".bold().cyan());
 
-    // ── config 読み込み
+    // ── 1. config 読み込み
     let config = match load_config(config_path) {
         Ok(c) => {
             println!("  {} s3d.config.json を読み込みました", "✔".green());
@@ -23,23 +23,45 @@ pub fn run(config_path: &Path) -> Result<()> {
         }
     };
 
-    // ── 検証
-    let errors = validate_config_and_env(&config);
+    let project_root = config_path.parent().unwrap_or(Path::new("."));
+    let mut all_ok = true;
 
+    // ── 2. config + env 検証
+    let errors = validate_config_and_env(&config);
     if errors.is_empty() {
-        print_success(&config);
+        print_config_success(&config);
     } else {
+        all_ok = false;
         for e in &errors {
             println!("  {} {}", "✘".red(), e);
         }
-        println!();
+    }
+
+    // ── 3. strategy.json 検証
+    let strategy_path = project_root.join(config.strategy_json_path());
+    match validate_strategy_json(&strategy_path) {
+        Ok(msg) => println!("  {} {}", "✔".green(), msg),
+        Err(e) => {
+            println!("  {} {}", "✘".red(), e);
+            all_ok = false;
+        }
+    }
+
+    println!();
+    if all_ok {
+        println!("{}", "すべての検証が通過しました ✔".green().bold());
+    } else {
         println!("{}", "検証に失敗しました".red().bold());
     }
 
     Ok(())
 }
 
-fn print_success(config: &S3dCliConfig) {
+// ──────────────────────────────────────────────────────────────
+// Helpers
+// ──────────────────────────────────────────────────────────────
+
+fn print_config_success(config: &S3dCliConfig) {
     println!("  {} project       : {}", "✔".green(), config.project);
     println!(
         "  {} provider      : {}",
@@ -56,27 +78,62 @@ fn print_success(config: &S3dCliConfig) {
         "✔".green(),
         config.storage.cdn_base_url
     );
+    println!("  {} src_dir       : {}", "✔".green(), config.src_dir);
     println!("  {} output_dir    : {}", "✔".green(), config.output_dir);
     println!(
-        "  {} S3D_ACCESS_KEY_ID     : {}",
+        "  {} CLOUDFLARE_R2_ACCESS_KEY_ID     : {}",
         "✔".green(),
-        mask_env("S3D_ACCESS_KEY_ID")
+        mask_env_multi(&["CLOUDFLARE_R2_ACCESS_KEY_ID", "S3D_ACCESS_KEY_ID"])
     );
     println!(
-        "  {} S3D_SECRET_ACCESS_KEY : {}",
+        "  {} CLOUDFLARE_R2_SECRET_ACCESS_KEY : {}",
         "✔".green(),
-        mask_env("S3D_SECRET_ACCESS_KEY")
+        mask_env_multi(&["CLOUDFLARE_R2_SECRET_ACCESS_KEY", "S3D_SECRET_ACCESS_KEY"])
     );
-    println!();
-    println!("{}", "すべての検証が通過しました ✔".green().bold());
 }
 
-fn mask_env(var: &str) -> String {
-    match std::env::var(var) {
-        Ok(v) if v.len() > 4 => format!("{}****", &v[..4]),
-        Ok(v) if !v.is_empty() => "****".to_string(),
-        _ => "(未設定)".red().to_string(),
+/// `src/assetsStrategy/strategy.json` を読み込み、必須フィールドを確認する
+fn validate_strategy_json(path: &Path) -> Result<String, String> {
+    if !path.exists() {
+        return Err(format!(
+            "strategy.json が見つかりません: {} (s3d init で生成できます)",
+            path.display()
+        ));
     }
+    let content =
+        std::fs::read_to_string(path).map_err(|e| format!("strategy.json の読み込み失敗: {e}"))?;
+    let v: serde_json::Value =
+        serde_json::from_str(&content).map_err(|e| format!("strategy.json のパース失敗: {e}"))?;
+
+    let mut missing = Vec::new();
+    for key in ["initial", "cdn", "reload"] {
+        if v.get(key).is_none() {
+            missing.push(key);
+        }
+    }
+    if !missing.is_empty() {
+        return Err(format!(
+            "strategy.json に必須フィールドがありません: {}",
+            missing.join(", ")
+        ));
+    }
+
+    Ok(format!("strategy.json OK ({})", path.display()))
+}
+
+fn mask_env_multi(vars: &[&str]) -> String {
+    for var in vars {
+        if let Ok(v) = std::env::var(var) {
+            if !v.trim().is_empty() {
+                return if v.len() > 4 {
+                    format!("{}****", &v[..4])
+                } else {
+                    "****".to_string()
+                };
+            }
+        }
+    }
+    "(未設定)".red().to_string()
 }
 
 // ──────────────────────────────────────────────────────────────
@@ -89,17 +146,7 @@ mod tests {
     use crate::config::{save_config, CdnProvider, S3dCliConfig, StorageConfig};
     use tempfile::TempDir;
 
-    #[test]
-    fn test_validate_missing_config() {
-        let dir = TempDir::new().unwrap();
-        let cfg_path = dir.path().join("s3d.config.json");
-        // ファイルが存在しない場合はエラーではなく "✘" を表示するだけ
-        run(&cfg_path).unwrap();
-    }
-
-    #[test]
-    fn test_validate_valid_config() {
-        let dir = TempDir::new().unwrap();
+    fn make_config(dir: &TempDir) -> std::path::PathBuf {
         let cfg_path = dir.path().join("s3d.config.json");
         let cfg = S3dCliConfig {
             project: "proj".to_string(),
@@ -111,6 +158,7 @@ mod tests {
                 endpoint: None,
                 region: None,
             },
+            src_dir: "src".to_string(),
             output_dir: "output".to_string(),
             include: vec![],
             exclude: vec![],
@@ -118,7 +166,64 @@ mod tests {
             manifest_path: None,
         };
         save_config(&cfg_path, &cfg).unwrap();
-        // 環境変数なしでも run は panic しない
+        cfg_path
+    }
+
+    #[test]
+    fn test_validate_missing_config() {
+        let dir = TempDir::new().unwrap();
+        let cfg_path = dir.path().join("s3d.config.json");
+        run(&cfg_path).unwrap(); // パニックしない
+    }
+
+    #[test]
+    fn test_validate_missing_strategy() {
+        let dir = TempDir::new().unwrap();
+        let cfg_path = make_config(&dir);
+        // strategy.json がない → エラーメッセージを表示するが panic しない
         run(&cfg_path).unwrap();
+    }
+
+    #[test]
+    fn test_validate_valid_strategy() {
+        let dir = TempDir::new().unwrap();
+        let cfg_path = make_config(&dir);
+
+        // strategy.json を生成
+        let strategy_dir = dir.path().join("src/assetsStrategy");
+        std::fs::create_dir_all(&strategy_dir).unwrap();
+        std::fs::write(
+            strategy_dir.join("strategy.json"),
+            r#"{"initial":{"sources":[],"cache":true},"cdn":{"files":[],"cache":true,"maxAge":"7d"},"reload":{"trigger":"manifest-change","strategy":"diff"}}"#,
+        )
+        .unwrap();
+
+        run(&cfg_path).unwrap();
+    }
+
+    #[test]
+    fn test_strategy_json_missing_fields() {
+        let path = std::path::Path::new("/dev/null"); // 空ファイル扱い
+                                                      // 空 JSON はパースエラー
+        assert!(validate_strategy_json(path).is_err());
+    }
+
+    #[test]
+    fn test_validate_strategy_json_missing_keys() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("strategy.json");
+        std::fs::write(&path, r#"{"initial":{}}"#).unwrap();
+        let result = validate_strategy_json(&path);
+        assert!(result.is_err());
+        let msg = result.unwrap_err();
+        assert!(msg.contains("cdn") || msg.contains("reload"));
+    }
+
+    #[test]
+    fn test_validate_strategy_json_ok() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("strategy.json");
+        std::fs::write(&path, r#"{"initial":{},"cdn":{},"reload":{}}"#).unwrap();
+        assert!(validate_strategy_json(&path).is_ok());
     }
 }

--- a/crates/s3d-cli/src/config.rs
+++ b/crates/s3d-cli/src/config.rs
@@ -56,7 +56,10 @@ pub struct StorageConfig {
 pub struct S3dCliConfig {
     pub project: String,
     pub storage: StorageConfig,
-    /// アセット収集のルートディレクトリ（デフォルト: "output"）
+    /// アセット収集のソースディレクトリ（デフォルト: "src"）
+    #[serde(default = "default_src_dir")]
+    pub src_dir: String,
+    /// ビルド出力ディレクトリ（デフォルト: "output"）
     #[serde(default = "default_output_dir")]
     pub output_dir: String,
     /// glob パターン（デフォルト: 空 = 全ファイル）
@@ -68,9 +71,13 @@ pub struct S3dCliConfig {
     /// 最大ファイルサイズ（例: "100MB"）
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub max_file_size: Option<String>,
-    /// manifest.json の出力先（デフォルト: output_dir）
+    /// manifest.json の出力先（デフォルト: output_dir/manifest.json）
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub manifest_path: Option<String>,
+}
+
+fn default_src_dir() -> String {
+    "src".to_string()
 }
 
 fn default_output_dir() -> String {
@@ -85,6 +92,13 @@ impl S3dCliConfig {
         } else {
             PathBuf::from(&self.output_dir).join("manifest.json")
         }
+    }
+
+    /// assetsStrategy/strategy.json のパスを解決する（src_dir 相対）
+    pub fn strategy_json_path(&self) -> PathBuf {
+        PathBuf::from(&self.src_dir)
+            .join("assetsStrategy")
+            .join("strategy.json")
     }
 }
 
@@ -128,15 +142,26 @@ pub fn validate_config_and_env(config: &S3dCliConfig) -> Vec<String> {
         errors.push("storage.cdn_base_url が空です".to_string());
     }
 
-    // 必須環境変数
+    // 必須環境変数（CLOUDFLARE_R2_* または S3D_* にフォールバック）
     let required_env = match config.storage.provider {
-        CdnProvider::CloudflareR2 => vec!["S3D_ACCESS_KEY_ID", "S3D_SECRET_ACCESS_KEY"],
-        CdnProvider::AwsS3 => vec!["S3D_ACCESS_KEY_ID", "S3D_SECRET_ACCESS_KEY"],
-        CdnProvider::Custom => vec!["S3D_ACCESS_KEY_ID", "S3D_SECRET_ACCESS_KEY"],
+        CdnProvider::CloudflareR2 => vec![
+            ("CLOUDFLARE_R2_ACCESS_KEY_ID", "S3D_ACCESS_KEY_ID"),
+            ("CLOUDFLARE_R2_SECRET_ACCESS_KEY", "S3D_SECRET_ACCESS_KEY"),
+        ],
+        CdnProvider::AwsS3 | CdnProvider::Custom => vec![
+            ("S3D_ACCESS_KEY_ID", "S3D_ACCESS_KEY_ID"),
+            ("S3D_SECRET_ACCESS_KEY", "S3D_SECRET_ACCESS_KEY"),
+        ],
     };
-    for var in required_env {
-        if std::env::var(var).unwrap_or_default().trim().is_empty() {
-            errors.push(format!("環境変数 {var} が未設定です"));
+    for (primary, fallback) in required_env {
+        let val = std::env::var(primary).unwrap_or_default();
+        let val = if val.trim().is_empty() {
+            std::env::var(fallback).unwrap_or_default()
+        } else {
+            val
+        };
+        if val.trim().is_empty() {
+            errors.push(format!("環境変数 {primary} が未設定です"));
         }
     }
 
@@ -163,12 +188,22 @@ mod tests {
                 endpoint: None,
                 region: None,
             },
+            src_dir: "src".to_string(),
             output_dir: "output".to_string(),
             include: vec![],
             exclude: vec![],
             max_file_size: None,
             manifest_path: None,
         }
+    }
+
+    #[test]
+    fn test_strategy_json_path() {
+        let cfg = sample_config();
+        assert_eq!(
+            cfg.strategy_json_path(),
+            PathBuf::from("src/assetsStrategy/strategy.json")
+        );
     }
 
     #[test]

--- a/crates/s3d-cli/src/storage/credentials.rs
+++ b/crates/s3d-cli/src/storage/credentials.rs
@@ -1,6 +1,12 @@
 //! 認証情報ヘルパー
 //!
-//! 環境変数 `S3D_ACCESS_KEY_ID` / `S3D_SECRET_ACCESS_KEY` を読み取る。
+//! 環境変数から R2/S3 アクセスキーを読み取る。
+//!
+//! Cloudflare R2 向け推奨変数:
+//!   `CLOUDFLARE_ACCOUNT_ID`, `CLOUDFLARE_R2_ACCESS_KEY_ID`, `CLOUDFLARE_R2_SECRET_ACCESS_KEY`
+//!
+//! 後方互換のフォールバック:
+//!   `S3D_ACCESS_KEY_ID`, `S3D_SECRET_ACCESS_KEY`
 
 use anyhow::{Context, Result};
 
@@ -12,16 +18,43 @@ pub struct StorageCredentials {
 }
 
 impl StorageCredentials {
-    /// 環境変数から認証情報を読み込む
+    /// 環境変数から認証情報を読み込む。
+    ///
+    /// 優先順:
+    /// 1. `CLOUDFLARE_R2_ACCESS_KEY_ID` / `CLOUDFLARE_R2_SECRET_ACCESS_KEY`
+    /// 2. `S3D_ACCESS_KEY_ID` / `S3D_SECRET_ACCESS_KEY`
     pub fn from_env() -> Result<Self> {
-        let access_key_id = std::env::var("S3D_ACCESS_KEY_ID")
-            .context("環境変数 S3D_ACCESS_KEY_ID が未設定です")?;
-        let secret_access_key = std::env::var("S3D_SECRET_ACCESS_KEY")
-            .context("環境変数 S3D_SECRET_ACCESS_KEY が未設定です")?;
+        let access_key_id =
+            read_env_with_fallback("CLOUDFLARE_R2_ACCESS_KEY_ID", "S3D_ACCESS_KEY_ID").context(
+                "環境変数 CLOUDFLARE_R2_ACCESS_KEY_ID (または S3D_ACCESS_KEY_ID) が未設定です",
+            )?;
+
+        let secret_access_key = read_env_with_fallback(
+            "CLOUDFLARE_R2_SECRET_ACCESS_KEY",
+            "S3D_SECRET_ACCESS_KEY",
+        )
+        .context(
+            "環境変数 CLOUDFLARE_R2_SECRET_ACCESS_KEY (または S3D_SECRET_ACCESS_KEY) が未設定です",
+        )?;
+
         Ok(Self {
             access_key_id,
             secret_access_key,
         })
+    }
+}
+
+/// primary を優先し、未設定なら fallback を読む
+fn read_env_with_fallback(primary: &str, fallback: &str) -> Option<String> {
+    let v = std::env::var(primary).unwrap_or_default();
+    if !v.trim().is_empty() {
+        return Some(v);
+    }
+    let v = std::env::var(fallback).unwrap_or_default();
+    if !v.trim().is_empty() {
+        Some(v)
+    } else {
+        None
     }
 }
 
@@ -31,9 +64,39 @@ mod tests {
 
     #[test]
     fn test_from_env_missing() {
-        // Ensure vars are unset for this test
+        std::env::remove_var("CLOUDFLARE_R2_ACCESS_KEY_ID");
+        std::env::remove_var("CLOUDFLARE_R2_SECRET_ACCESS_KEY");
         std::env::remove_var("S3D_ACCESS_KEY_ID");
         std::env::remove_var("S3D_SECRET_ACCESS_KEY");
         assert!(StorageCredentials::from_env().is_err());
+    }
+
+    #[test]
+    fn test_from_env_cloudflare_vars() {
+        std::env::set_var("CLOUDFLARE_R2_ACCESS_KEY_ID", "cfkey");
+        std::env::set_var("CLOUDFLARE_R2_SECRET_ACCESS_KEY", "cfsecret");
+        std::env::remove_var("S3D_ACCESS_KEY_ID");
+        std::env::remove_var("S3D_SECRET_ACCESS_KEY");
+
+        let creds = StorageCredentials::from_env().unwrap();
+        assert_eq!(creds.access_key_id, "cfkey");
+        assert_eq!(creds.secret_access_key, "cfsecret");
+
+        std::env::remove_var("CLOUDFLARE_R2_ACCESS_KEY_ID");
+        std::env::remove_var("CLOUDFLARE_R2_SECRET_ACCESS_KEY");
+    }
+
+    #[test]
+    fn test_from_env_fallback_s3d_vars() {
+        std::env::remove_var("CLOUDFLARE_R2_ACCESS_KEY_ID");
+        std::env::remove_var("CLOUDFLARE_R2_SECRET_ACCESS_KEY");
+        std::env::set_var("S3D_ACCESS_KEY_ID", "s3dkey");
+        std::env::set_var("S3D_SECRET_ACCESS_KEY", "s3dsecret");
+
+        let creds = StorageCredentials::from_env().unwrap();
+        assert_eq!(creds.access_key_id, "s3dkey");
+
+        std::env::remove_var("S3D_ACCESS_KEY_ID");
+        std::env::remove_var("S3D_SECRET_ACCESS_KEY");
     }
 }


### PR DESCRIPTION
## 概要

Issue #14 の追加要件を実装。Issue #12 で作成した `s3d-cli` を拡張し、
開発者体験（src/ スキャフォールド・Cloudflare R2 認証情報・assetsStrategy 検証）を完成させる。

---

## 変更ファイル

### `src/commands/init.rs` — src/ スキャフォールド生成

`s3d init` 実行後に以下を生成するよう拡張:

```
my-service/
├─ s3d.config.json
├─ .env.example          ← CLOUDFLARE_R2_ACCESS_KEY_ID / CLOUDFLARE_R2_SECRET_ACCESS_KEY
├─ .gitignore            ← /target, .env, output/ を含む
├─ src/
│   ├─ index.html        ← プロジェクト名入りテンプレート
│   ├─ assetsStrategy/
│   │   └─ strategy.json ← initial/cdn/reload 戦略
│   └─ assets/
│       └─ .gitkeep
└─ output/
```

### `src/commands/build.rs` — src/ → output/ 分離

- ソースを `src_dir` (デフォルト `src/`) から収集
- ハッシュ付きファイルを `output/` にコピー（`src/` を汚さない）
- `src/` 不在時の分かりやすいエラーメッセージ

### `src/commands/validate.rs` — strategy.json 検証追加

- `src/assetsStrategy/strategy.json` の必須フィールド (initial/cdn/reload) をチェック
- ファイル不在の場合は `s3d init` を促すメッセージ

### `src/config.rs` — src_dir フィールド・CLOUDFLARE_R2_* 対応

- `S3dCliConfig` に `src_dir` フィールド追加（デフォルト: `"src"`）
- `strategy_json_path()` メソッド追加
- `validate_config_and_env()` を `CLOUDFLARE_R2_*` → `S3D_*` フォールバック方式に変更

### `src/storage/credentials.rs` — Cloudflare R2 認証情報対応

優先順: `CLOUDFLARE_R2_ACCESS_KEY_ID` → `S3D_ACCESS_KEY_ID` (フォールバック)

### ルートファイル

- `.env.example`: `CLOUDFLARE_ACCOUNT_ID` / `CLOUDFLARE_R2_ACCESS_KEY_ID` / `CLOUDFLARE_R2_SECRET_ACCESS_KEY` に更新
- `.gitignore`: `output/` を追加
- `README.md`: 開発者体験セクション（ディレクトリ構造・2つのアセット配信方法・strategy.json例）追加

---

## テスト結果

```
cargo test -p s3d-cli → 33 passed, 0 failed, 1 ignored
```

新規テスト: test_scaffold_src_structure, test_index_html_contains_project_name, test_strategy_json_valid, test_env_example_cloudflare, test_gitignore_contains_output, test_build_creates_manifest_and_hashed_files, test_build_src_not_found, test_validate_valid_strategy, test_validate_strategy_json_ok/missing_keys, test_from_env_cloudflare_vars/fallback_s3d_vars, test_strategy_json_path