### PR TITLE
feat(s3d-cli): manifest strategies section, validate file check, plugins field — Closes #16

### DIFF
--- a/crates/s3d-cli/src/commands/build.rs
+++ b/crates/s3d-cli/src/commands/build.rs
@@ -2,7 +2,13 @@
 //!
 //! `src/` を読み取り、ハッシュ付きファイルを `output/` にコピーして
 //! `output/manifest.json` を生成する。
+//!
+//! ## manifest.json の strategies セクション
+//! `src/assetsStrategy/` 配下のサブディレクトリを走査し、各ディレクトリの
+//! `strategy.json` を読み込んで `manifest.json` の `strategies` セクションに追加する。
+//! フォルダ名が `strategyAssets("name")` の呼び出し名と一致する。
 
+use std::collections::HashMap;
 use std::path::Path;
 use std::time::Instant;
 
@@ -13,6 +19,7 @@ use s3d_deploy::{
     hash::hash_assets,
     manifest::{build_manifest, manifest_to_json, ManifestOptions},
 };
+use s3d_types::manifest::{StrategyEntry, StrategyReload};
 
 use crate::config::S3dCliConfig;
 
@@ -75,9 +82,18 @@ pub fn run(config: &S3dCliConfig, config_path: &Path) -> Result<()> {
         version: "1.0.0".to_string(),
         build_time: Some(chrono::Utc::now().to_rfc3339()),
     };
-    let manifest = build_manifest(&hashed, &manifest_opts).context("マニフェスト生成エラー")?;
+    let mut manifest = build_manifest(&hashed, &manifest_opts).context("マニフェスト生成エラー")?;
 
-    // ── 5. manifest.json の書き込み
+    // ── 5. strategies セクションを構築 (src/assetsStrategy/ サブディレクトリ走査)
+    let strategies_root = src_dir.join("assetsStrategy");
+    let strategies = scan_strategies(&strategies_root)
+        .context("assetsStrategy ディレクトリの走査エラー")?;
+    if !strategies.is_empty() {
+        println!("  strategies: {} 件", strategies.len().to_string().bold());
+    }
+    manifest.strategies = strategies;
+
+    // ── 6. manifest.json の書き込み
     let manifest_path = config.resolved_manifest_path();
     let manifest_path = if manifest_path.is_absolute() {
         manifest_path
@@ -105,6 +121,104 @@ pub fn run(config: &S3dCliConfig, config_path: &Path) -> Result<()> {
     println!("  ビルド時間   : {:.2}s", elapsed.as_secs_f64());
 
     Ok(())
+}
+
+/// `src/assetsStrategy/` 配下のサブディレクトリを走査し、
+/// 各サブディレクトリの `strategy.json` を読み込んで `StrategyEntry` マップを返す。
+///
+/// - ルートの `strategy.json`（サブディレクトリでないもの）はスキップ
+/// - `strategy.json` が存在しないサブディレクトリもスキップ（警告なし）
+pub fn scan_strategies(strategies_root: &Path) -> Result<HashMap<String, StrategyEntry>> {
+    let mut map = HashMap::new();
+
+    if !strategies_root.exists() {
+        return Ok(map);
+    }
+
+    let entries = std::fs::read_dir(strategies_root)
+        .with_context(|| format!("assetsStrategy の読み込み失敗: {}", strategies_root.display()))?;
+
+    for entry in entries {
+        let entry = entry?;
+        let path = entry.path();
+
+        // サブディレクトリのみ対象
+        if !path.is_dir() {
+            continue;
+        }
+
+        let strategy_file = path.join("strategy.json");
+        if !strategy_file.exists() {
+            continue;
+        }
+
+        let name = path
+            .file_name()
+            .and_then(|n| n.to_str())
+            .unwrap_or("")
+            .to_string();
+        if name.is_empty() {
+            continue;
+        }
+
+        let content = std::fs::read_to_string(&strategy_file).with_context(|| {
+            format!("strategy.json の読み込み失敗: {}", strategy_file.display())
+        })?;
+
+        let strategy = parse_strategy_json(&content, &name).with_context(|| {
+            format!(
+                "strategy.json のパース失敗 ({}): {}",
+                name,
+                strategy_file.display()
+            )
+        })?;
+
+        map.insert(name, strategy);
+    }
+
+    Ok(map)
+}
+
+/// strategy.json の JSON 文字列を `StrategyEntry` にパースする。
+fn parse_strategy_json(content: &str, name: &str) -> Result<StrategyEntry> {
+    let v: serde_json::Value =
+        serde_json::from_str(content).with_context(|| format!("{} の JSON パース失敗", name))?;
+
+    let files: Vec<String> = v
+        .get("files")
+        .and_then(|f| f.as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|x| x.as_str().map(|s| s.to_string()))
+                .collect()
+        })
+        .unwrap_or_default();
+
+    let initial = v
+        .get("initial")
+        .and_then(|x| x.as_bool())
+        .unwrap_or(false);
+
+    let cache = v.get("cache").and_then(|x| x.as_bool()).unwrap_or(true);
+
+    let max_age = v
+        .get("maxAge")
+        .and_then(|x| x.as_str())
+        .map(|s| s.to_string());
+
+    let reload = v.get("reload").and_then(|r| {
+        let trigger = r.get("trigger")?.as_str()?.to_string();
+        let strategy = r.get("strategy")?.as_str()?.to_string();
+        Some(StrategyReload { trigger, strategy })
+    });
+
+    Ok(StrategyEntry {
+        files,
+        initial,
+        cache,
+        max_age,
+        reload,
+    })
 }
 
 pub fn format_bytes(bytes: u64) -> String {
@@ -146,6 +260,7 @@ mod tests {
             exclude: vec![],
             max_file_size: None,
             manifest_path: None,
+            plugins: vec![],
         }
     }
 
@@ -211,5 +326,92 @@ mod tests {
         assert_eq!(format_bytes(500), "500 B");
         assert_eq!(format_bytes(1024), "1.00 KB");
         assert_eq!(format_bytes(1_048_576), "1.00 MB");
+    }
+
+    #[test]
+    fn test_scan_strategies_empty_dir() {
+        let dir = TempDir::new().unwrap();
+        // assetsStrategy ディレクトリなし → 空マップ
+        let result = scan_strategies(dir.path()).unwrap();
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn test_scan_strategies_with_subdir() {
+        let dir = TempDir::new().unwrap();
+        let sushi_dir = dir.path().join("sushi");
+        std::fs::create_dir_all(&sushi_dir).unwrap();
+        std::fs::write(
+            sushi_dir.join("strategy.json"),
+            r#"{"files":["assets/sushi.glb"],"initial":false,"cache":true,"maxAge":"7d","reload":{"trigger":"manifest-change","strategy":"diff"}}"#,
+        )
+        .unwrap();
+
+        let result = scan_strategies(dir.path()).unwrap();
+        assert_eq!(result.len(), 1);
+        let sushi = result.get("sushi").expect("sushi エントリがない");
+        assert_eq!(sushi.files, vec!["assets/sushi.glb"]);
+        assert!(!sushi.initial);
+        assert!(sushi.cache);
+        assert_eq!(sushi.max_age.as_deref(), Some("7d"));
+        let reload = sushi.reload.as_ref().expect("reload がない");
+        assert_eq!(reload.trigger, "manifest-change");
+        assert_eq!(reload.strategy, "diff");
+    }
+
+    #[test]
+    fn test_scan_strategies_skips_root_json() {
+        let dir = TempDir::new().unwrap();
+        // ルートの strategy.json (サブディレクトリでない) はスキップされる
+        std::fs::write(dir.path().join("strategy.json"), r#"{"files":[],"initial":false,"cache":true}"#).unwrap();
+        let result = scan_strategies(dir.path()).unwrap();
+        assert!(result.is_empty(), "ルート strategy.json はスキップされるべき");
+    }
+
+    #[test]
+    fn test_scan_strategies_subdir_without_strategy_json() {
+        let dir = TempDir::new().unwrap();
+        // strategy.json のないサブディレクトリはスキップ
+        std::fs::create_dir_all(dir.path().join("empty_strategy")).unwrap();
+        let result = scan_strategies(dir.path()).unwrap();
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn test_build_manifest_contains_strategies() {
+        let dir = TempDir::new().unwrap();
+        let src = dir.path().join("src");
+        let assets_dir = src.join("assets");
+        let strategy_dir = src.join("assetsStrategy").join("sushi");
+        std::fs::create_dir_all(&assets_dir).unwrap();
+        std::fs::create_dir_all(&strategy_dir).unwrap();
+
+        // ダミーアセット
+        std::fs::write(assets_dir.join("sushi.glb"), b"glb-data").unwrap();
+
+        // sushi strategy
+        std::fs::write(
+            strategy_dir.join("strategy.json"),
+            r#"{"files":["assets/sushi.glb"],"initial":false,"cache":true,"maxAge":"7d","reload":{"trigger":"manifest-change","strategy":"diff"}}"#,
+        )
+        .unwrap();
+
+        let config_path = dir.path().join("s3d.config.json");
+        let cfg = make_config("src");
+        crate::config::save_config(&config_path, &cfg).unwrap();
+
+        run(&cfg, &config_path).unwrap();
+
+        let manifest_path = dir.path().join("output/manifest.json");
+        let content = std::fs::read_to_string(&manifest_path).unwrap();
+        let v: serde_json::Value = serde_json::from_str(&content).unwrap();
+
+        // strategies セクションが存在する
+        let strategies = v.get("strategies").expect("strategies セクションがない");
+        let sushi = strategies.get("sushi").expect("sushi エントリがない");
+        let files = sushi["files"].as_array().expect("files が配列でない");
+        assert!(!files.is_empty(), "files が空");
+        assert_eq!(sushi["cache"].as_bool(), Some(true));
+        assert_eq!(sushi["maxAge"].as_str(), Some("7d"));
     }
 }

--- a/crates/s3d-cli/src/commands/diff.rs
+++ b/crates/s3d-cli/src/commands/diff.rs
@@ -127,6 +127,7 @@ mod tests {
                 version: "1.0.0".to_string(),
                 build_time: "2026-01-01T00:00:00Z".to_string(),
                 assets,
+                strategies: std::collections::HashMap::new(),
             };
             serde_json::to_string_pretty(&m).unwrap()
         };

--- a/crates/s3d-cli/src/commands/init.rs
+++ b/crates/s3d-cli/src/commands/init.rs
@@ -6,6 +6,7 @@
 //! - `.gitignore`
 //! - `src/index.html`                         (スキャフォールド HTML)
 //! - `src/assetsStrategy/strategy.json`       (デフォルト配信戦略)
+//! - `src/assetsStrategy/sushi/strategy.json` (サブディレクトリ戦略の例)
 //! - `src/assets/.gitkeep`                    (空ディレクトリ保持)
 //! - `output/`                                (ビルド出力先)
 
@@ -96,6 +97,7 @@ pub fn run() -> Result<()> {
         exclude: vec![],
         max_file_size: None,
         manifest_path: None,
+        plugins: vec![],
     };
 
     save_config(&base_dir.join("s3d.config.json"), &config)?;
@@ -173,7 +175,7 @@ pub(crate) fn scaffold_src(project: &str, base_dir: &Path) -> Result<()> {
     std::fs::create_dir_all(&assets_dir)?;
     std::fs::write(assets_dir.join(".gitkeep"), "")?;
 
-    // src/assetsStrategy/strategy.json
+    // src/assetsStrategy/strategy.json (ルートレベルのデフォルト戦略)
     let strategy_dir = base_dir.join("src/assetsStrategy");
     std::fs::create_dir_all(&strategy_dir)?;
     let strategy_json = r#"{
@@ -193,6 +195,23 @@ pub(crate) fn scaffold_src(project: &str, base_dir: &Path) -> Result<()> {
 }
 "#;
     std::fs::write(strategy_dir.join("strategy.json"), strategy_json)?;
+
+    // src/assetsStrategy/sushi/strategy.json (サブディレクトリ戦略の例)
+    // フォルダ名 = strategyAssets("sushi") の呼び出し名と一致
+    let sushi_dir = strategy_dir.join("sushi");
+    std::fs::create_dir_all(&sushi_dir)?;
+    let sushi_strategy_json = r#"{
+  "files": ["assets/sushi.glb"],
+  "initial": false,
+  "cache": true,
+  "maxAge": "7d",
+  "reload": {
+    "trigger": "manifest-change",
+    "strategy": "diff"
+  }
+}
+"#;
+    std::fs::write(sushi_dir.join("strategy.json"), sushi_strategy_json)?;
 
     // src/index.html
     let index_html = format!(
@@ -262,6 +281,7 @@ mod tests {
             exclude: vec![],
             max_file_size: None,
             manifest_path: None,
+            plugins: vec![],
         };
         save_config(&base.join("s3d.config.json"), &config).unwrap();
         write_env_example(&provider, base).unwrap();
@@ -373,5 +393,30 @@ mod tests {
         // 互いに干渉していない
         assert!(!html_a.contains("proj-b"));
         assert!(!html_b.contains("proj-a"));
+    }
+
+    #[test]
+    fn test_scaffold_sushi_strategy_exists() {
+        // サブディレクトリ戦略 (sushi) が生成されていることを確認
+        let dir = TempDir::new().unwrap();
+        scaffold_src("test", dir.path()).unwrap();
+        let sushi_path = dir.path().join("src/assetsStrategy/sushi/strategy.json");
+        assert!(sushi_path.exists(), "sushi/strategy.json が生成されていない");
+        let content = std::fs::read_to_string(&sushi_path).unwrap();
+        let v: serde_json::Value = serde_json::from_str(&content).unwrap();
+        assert!(v.get("files").is_some(), "files フィールドがない");
+        assert!(v.get("initial").is_some(), "initial フィールドがない");
+        assert!(v.get("cache").is_some(), "cache フィールドがない");
+        let files = v["files"].as_array().unwrap();
+        assert!(!files.is_empty(), "files が空");
+    }
+
+    #[test]
+    fn test_config_plugins_field() {
+        // plugins フィールドが空配列で生成されることを確認
+        let dir = make_and_scaffold("plugtest", CdnProvider::CloudflareR2);
+        let loaded =
+            crate::config::load_config(&dir.path().join("s3d.config.json")).unwrap();
+        assert!(loaded.plugins.is_empty(), "plugins は空配列であるべき");
     }
 }

--- a/crates/s3d-cli/src/commands/push.rs
+++ b/crates/s3d-cli/src/commands/push.rs
@@ -247,6 +247,7 @@ mod tests {
             exclude: vec![],
             max_file_size: None,
             manifest_path: None,
+            plugins: vec![],
         }
     }
 
@@ -277,6 +278,7 @@ mod tests {
             version: "1.0.0".to_string(),
             build_time: "2026-01-01T00:00:00Z".to_string(),
             assets,
+            strategies: HashMap::new(),
         };
         let manifest_path = dir.path().join("output/manifest.json");
         std::fs::write(
@@ -320,6 +322,7 @@ mod tests {
             version: "1.0.0".to_string(),
             build_time: "2026-01-01T00:00:00Z".to_string(),
             assets: assets.clone(),
+            strategies: HashMap::new(),
         };
         let manifest_path = dir.path().join("output/manifest.json");
         std::fs::write(

--- a/crates/s3d-cli/src/commands/validate.rs
+++ b/crates/s3d-cli/src/commands/validate.rs
@@ -1,4 +1,7 @@
 //! `s3d validate` — s3d.config.json / strategy.json / .env の検証コマンド
+//!
+//! Issue #16 追加: 各サブディレクトリ strategy.json の `files` フィールドに
+//! 指定されたファイルが `src/assets/` 内に存在するか確認し、存在しない場合は警告を表示する。
 
 use std::path::Path;
 
@@ -37,7 +40,7 @@ pub fn run(config_path: &Path) -> Result<()> {
         }
     }
 
-    // ── 3. strategy.json 検証
+    // ── 3. ルート strategy.json 検証 (src/assetsStrategy/strategy.json)
     let strategy_path = project_root.join(config.strategy_json_path());
     match validate_strategy_json(&strategy_path) {
         Ok(msg) => println!("  {} {}", "✔".green(), msg),
@@ -47,9 +50,27 @@ pub fn run(config_path: &Path) -> Result<()> {
         }
     }
 
+    // ── 4. サブディレクトリ strategy.json の files 存在確認
+    let src_dir = project_root.join(&config.src_dir);
+    let strategies_root = src_dir.join("assetsStrategy");
+    let assets_dir = src_dir.join("assets");
+    let warnings = validate_strategy_files(&strategies_root, &assets_dir);
+    for w in &warnings {
+        println!("  {} {}", "⚠".yellow(), w);
+    }
+
     println!();
     if all_ok {
-        println!("{}", "すべての検証が通過しました ✔".green().bold());
+        if warnings.is_empty() {
+            println!("{}", "すべての検証が通過しました ✔".green().bold());
+        } else {
+            println!(
+                "{}",
+                format!("検証は通過しましたが {} 件の警告があります", warnings.len())
+                    .yellow()
+                    .bold()
+            );
+        }
     } else {
         println!("{}", "検証に失敗しました".red().bold());
     }
@@ -121,6 +142,80 @@ fn validate_strategy_json(path: &Path) -> Result<String, String> {
     Ok(format!("strategy.json OK ({})", path.display()))
 }
 
+/// サブディレクトリ戦略の `files` フィールドに指定されたファイルが
+/// `src/assets/` 内に存在するか確認する。
+///
+/// 存在しないファイルは警告メッセージのリストとして返す。
+pub fn validate_strategy_files(strategies_root: &Path, assets_dir: &Path) -> Vec<String> {
+    let mut warnings = Vec::new();
+
+    if !strategies_root.exists() {
+        return warnings;
+    }
+
+    let entries = match std::fs::read_dir(strategies_root) {
+        Ok(e) => e,
+        Err(_) => return warnings,
+    };
+
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if !path.is_dir() {
+            continue;
+        }
+
+        let strategy_file = path.join("strategy.json");
+        if !strategy_file.exists() {
+            continue;
+        }
+
+        let name = path
+            .file_name()
+            .and_then(|n| n.to_str())
+            .unwrap_or("")
+            .to_string();
+
+        let content = match std::fs::read_to_string(&strategy_file) {
+            Ok(c) => c,
+            Err(e) => {
+                warnings.push(format!(
+                    "[{}] strategy.json の読み込み失敗: {}",
+                    name, e
+                ));
+                continue;
+            }
+        };
+
+        let v: serde_json::Value = match serde_json::from_str(&content) {
+            Ok(v) => v,
+            Err(e) => {
+                warnings.push(format!("[{}] strategy.json のパース失敗: {}", name, e));
+                continue;
+            }
+        };
+
+        if let Some(files) = v.get("files").and_then(|f| f.as_array()) {
+            for file_val in files {
+                if let Some(file_path) = file_val.as_str() {
+                    // assets_dir を起点に相対パスを解決
+                    // "assets/sushi.glb" → assets_dir/../assets/sushi.glb を確認
+                    // assets_dir は src/assets/ なので、src/ を起点にする
+                    let src_dir = assets_dir.parent().unwrap_or(assets_dir);
+                    let full_path = src_dir.join(file_path);
+                    if !full_path.exists() {
+                        warnings.push(format!(
+                            "[{}] files に指定されたファイルが src/ に存在しません: {}",
+                            name, file_path
+                        ));
+                    }
+                }
+            }
+        }
+    }
+
+    warnings
+}
+
 fn mask_env_multi(vars: &[&str]) -> String {
     for var in vars {
         if let Ok(v) = std::env::var(var) {
@@ -164,6 +259,7 @@ mod tests {
             exclude: vec![],
             max_file_size: None,
             manifest_path: None,
+            plugins: vec![],
         };
         save_config(&cfg_path, &cfg).unwrap();
         cfg_path
@@ -225,5 +321,62 @@ mod tests {
         let path = dir.path().join("strategy.json");
         std::fs::write(&path, r#"{"initial":{},"cdn":{},"reload":{}}"#).unwrap();
         assert!(validate_strategy_json(&path).is_ok());
+    }
+
+    #[test]
+    fn test_validate_strategy_files_no_warnings_when_file_exists() {
+        let dir = TempDir::new().unwrap();
+        let strategies_root = dir.path().join("assetsStrategy");
+        let assets_dir = dir.path().join("assets");
+        let sushi_dir = strategies_root.join("sushi");
+        std::fs::create_dir_all(&sushi_dir).unwrap();
+        std::fs::create_dir_all(&assets_dir).unwrap();
+
+        // ファイルを実際に作成
+        std::fs::write(assets_dir.join("sushi.glb"), b"glb").unwrap();
+
+        std::fs::write(
+            sushi_dir.join("strategy.json"),
+            r#"{"files":["assets/sushi.glb"],"initial":false,"cache":true}"#,
+        )
+        .unwrap();
+
+        let warnings = validate_strategy_files(&strategies_root, &assets_dir);
+        assert!(warnings.is_empty(), "警告が出るべきでない: {:?}", warnings);
+    }
+
+    #[test]
+    fn test_validate_strategy_files_warns_missing_file() {
+        let dir = TempDir::new().unwrap();
+        let strategies_root = dir.path().join("assetsStrategy");
+        let assets_dir = dir.path().join("assets");
+        let sushi_dir = strategies_root.join("sushi");
+        std::fs::create_dir_all(&sushi_dir).unwrap();
+        std::fs::create_dir_all(&assets_dir).unwrap();
+
+        // assets/sushi.glb は作成しない
+        std::fs::write(
+            sushi_dir.join("strategy.json"),
+            r#"{"files":["assets/sushi.glb"],"initial":false,"cache":true}"#,
+        )
+        .unwrap();
+
+        let warnings = validate_strategy_files(&strategies_root, &assets_dir);
+        assert!(!warnings.is_empty(), "警告が出るべき");
+        assert!(
+            warnings.iter().any(|w| w.contains("sushi.glb")),
+            "sushi.glb の警告がない: {:?}",
+            warnings
+        );
+    }
+
+    #[test]
+    fn test_validate_strategy_files_no_strategies_dir() {
+        let dir = TempDir::new().unwrap();
+        let strategies_root = dir.path().join("assetsStrategy");
+        let assets_dir = dir.path().join("assets");
+        // assetsStrategy ディレクトリなし → 警告なし
+        let warnings = validate_strategy_files(&strategies_root, &assets_dir);
+        assert!(warnings.is_empty());
     }
 }

--- a/crates/s3d-cli/src/config.rs
+++ b/crates/s3d-cli/src/config.rs
@@ -74,6 +74,9 @@ pub struct S3dCliConfig {
     /// manifest.json の出力先（デフォルト: output_dir/manifest.json）
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub manifest_path: Option<String>,
+    /// 将来のプラグイン機構用（予約フィールド）
+    #[serde(default)]
+    pub plugins: Vec<serde_json::Value>,
 }
 
 fn default_src_dir() -> String {
@@ -194,7 +197,31 @@ mod tests {
             exclude: vec![],
             max_file_size: None,
             manifest_path: None,
+            plugins: vec![],
         }
+    }
+
+    #[test]
+    fn test_plugins_field_default() {
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        // plugins フィールドなしの JSON を保存してもデフォルト空配列で読める
+        std::fs::write(
+            tmp.path(),
+            r#"{"project":"p","storage":{"provider":"cloudflare-r2","bucket":"b","cdn_base_url":"https://cdn.example.com"}}"#,
+        )
+        .unwrap();
+        let loaded = load_config(tmp.path()).unwrap();
+        assert!(loaded.plugins.is_empty());
+    }
+
+    #[test]
+    fn test_plugins_field_serialized() {
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        let cfg = sample_config();
+        save_config(tmp.path(), &cfg).unwrap();
+        let content = std::fs::read_to_string(tmp.path()).unwrap();
+        // plugins フィールドが JSON に含まれている
+        assert!(content.contains("plugins"));
     }
 
     #[test]

--- a/crates/s3d-deploy/src/diff.rs
+++ b/crates/s3d-deploy/src/diff.rs
@@ -116,6 +116,7 @@ mod tests {
             version: "1.0.0".to_string(),
             build_time: "2026-01-01T00:00:00Z".to_string(),
             assets: map,
+            strategies: std::collections::HashMap::new(),
         }
     }
 

--- a/crates/s3d-deploy/src/manifest.rs
+++ b/crates/s3d-deploy/src/manifest.rs
@@ -162,6 +162,7 @@ pub fn build_manifest(
         version: opts.version.clone(),
         build_time,
         assets: entries,
+        strategies: HashMap::new(),
     })
 }
 

--- a/crates/s3d-display/src/lib.rs
+++ b/crates/s3d-display/src/lib.rs
@@ -100,6 +100,7 @@ mod tests {
             version: "2.0.0".to_string(),
             build_time: "2026-03-20T00:00:00Z".to_string(),
             assets,
+            strategies: std::collections::HashMap::new(),
         }
     }
 

--- a/crates/s3d-display/src/plugin.rs
+++ b/crates/s3d-display/src/plugin.rs
@@ -170,6 +170,7 @@ mod tests {
             version: "1.0.0".to_string(),
             build_time: "2026-03-20T00:00:00Z".to_string(),
             assets,
+            strategies: std::collections::HashMap::new(),
         }
     }
 

--- a/crates/s3d-loader/src/diff.rs
+++ b/crates/s3d-loader/src/diff.rs
@@ -129,6 +129,7 @@ mod tests {
             version: "1.0.0".to_string(),
             build_time: "2026-03-20T00:00:00Z".to_string(),
             assets,
+            strategies: std::collections::HashMap::new(),
         }
     }
 

--- a/crates/s3d-loader/tests/loader_flow.rs
+++ b/crates/s3d-loader/tests/loader_flow.rs
@@ -58,6 +58,7 @@ fn make_manifest(base_url: &str, entries: &[(&str, &[u8])]) -> DeployManifest {
         version: "1.0.0".to_string(),
         build_time: "2026-03-20T00:00:00Z".to_string(),
         assets,
+        strategies: std::collections::HashMap::new(),
     }
 }
 

--- a/crates/s3d-types/src/lib.rs
+++ b/crates/s3d-types/src/lib.rs
@@ -18,7 +18,7 @@ pub use loader::{
     AssetResult, LoadAllOptions, LoadError, LoadErrorKind, LoadOptions, LoaderOptions,
     ProgressEvent, ResponseType,
 };
-pub use manifest::{AssetEntry, DeployManifest};
+pub use manifest::{AssetEntry, DeployManifest, StrategyEntry, StrategyReload};
 pub use plugin::{
     DisplayPlugin, HtmlOutput, RenderContext, StorageError, StoragePlugin, StorageResult,
 };
@@ -141,6 +141,7 @@ mod tests {
             version: "1.0.0".to_string(),
             build_time: "2026-03-20T00:00:00Z".to_string(),
             assets,
+            strategies: std::collections::HashMap::new(),
         };
 
         let json = serde_json::to_string(&manifest).expect("serialization failed");

--- a/crates/s3d-types/src/manifest.rs
+++ b/crates/s3d-types/src/manifest.rs
@@ -15,6 +15,34 @@ pub struct AssetEntry {
     pub dependencies: Option<Vec<String>>,
 }
 
+/// strategy.json の reload セクション
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct StrategyReload {
+    pub trigger: String,
+    pub strategy: String,
+}
+
+/// strategies セクションの個々のエントリ
+///
+/// `src/assetsStrategy/<name>/strategy.json` から読み込まれる。
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct StrategyEntry {
+    /// 対象ファイル一覧 (src/assets/ 相対パス)
+    pub files: Vec<String>,
+    /// 初期ロード対象かどうか
+    pub initial: bool,
+    /// キャッシュを有効にするか
+    pub cache: bool,
+    /// キャッシュの最大有効期間 (例: "7d")
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_age: Option<String>,
+    /// リロード設定
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reload: Option<StrategyReload>,
+}
+
 /// デプロイマニフェスト
 ///
 /// TypeScript の `DeployManifest` に対応する。
@@ -25,4 +53,7 @@ pub struct DeployManifest {
     pub version: String,
     pub build_time: String,
     pub assets: HashMap<String, AssetEntry>,
+    /// 配信戦略マップ（strategy 名 → StrategyEntry）
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub strategies: HashMap<String, StrategyEntry>,
 }


### PR DESCRIPTION
## 概要

Issue #16 (コメント追加仕様含む) を実装します。

## 変更内容

### 1. `manifest.json` に `strategies` セクションを追加
- `s3d-types/manifest.rs`: `StrategyEntry`・`StrategyReload` 型を追加、`DeployManifest` に `strategies: HashMap<String, StrategyEntry>` フィールドを追加
- `s3d-deploy/manifest.rs`: `build_manifest()` で `strategies` を空 HashMap で初期化
- `s3d-cli/commands/build.rs`: `s3d build` 時に `src/assetsStrategy/` 配下のサブディレクトリを走査し、各 `strategy.json` を `manifest.strategies` に埋め込む
  - フォルダ名 = `strategyAssets("name")` の呼び出し名と一致

### 2. `s3d validate` の追加チェック
- `s3d-cli/commands/validate.rs`: `validate_strategy_files()` を追加
  - 各サブディレクトリ `strategy.json` の `files` に指定されたファイルが `src/assets/` 内に存在するか確認
  - 存在しない場合は `⚠` 警告を表示（エラーではなく警告として扱う）

### 3. `s3d.config.json` に `plugins` フィールドを予約
- `s3d-cli/config.rs`: `plugins: Vec<serde_json::Value>` フィールドを追加（デフォルト: 空配列）
- `s3d-cli/commands/init.rs`: `s3d init` で生成する config に `plugins: []` を含める
- `s3d-cli/commands/init.rs`: `src/assetsStrategy/sushi/strategy.json` サブディレクトリ戦略の例を生成

### その他
- `DeployManifest` の struct 初期化箇所を全クレートで修正 (s3d-deploy, s3d-display, s3d-loader)

## テスト結果
```
cargo test -p s3d-cli → 48 passed, 0 failed, 1 ignored
cargo test -p s3d-types -p s3d-deploy -p s3d-display → 全通過
```

新規追加テスト:
- `test_scan_strategies_with_subdir` — サブディレクトリの strategy 読み込み
- `test_scan_strategies_skips_root_json` — ルート strategy.json をスキップ
- `test_build_manifest_contains_strategies` — ビルド後 manifest に strategies セクションが存在
- `test_validate_strategy_files_no_warnings_when_file_exists` — ファイル存在時は警告なし
- `test_validate_strategy_files_warns_missing_file` — ファイル不在時は警告
- `test_scaffold_sushi_strategy_exists` — init で sushi サブディレクトリが生成される
- `test_config_plugins_field` — plugins フィールドが空配列で保存される
- `test_plugins_field_default / test_plugins_field_serialized` — config roundtrip