### PR TITLE
fix(s3d-build): strategy-based hashing, exclude .gitkeep/assetsStrategy — Closes #23

### DIFF
--- a/crates/s3d-cli/src/commands/build.rs
+++ b/crates/s3d-cli/src/commands/build.rs
@@ -1,14 +1,20 @@
 //! `s3d build` — アセット収集・ハッシュ化・マニフェスト生成コマンド
 //!
-//! `src/` を読み取り、ハッシュ付きファイルを `output/` にコピーして
+//! `src/` を読み取り、ファイルを `output/` にコピーして
 //! `output/manifest.json` を生成する。
+//!
+//! ## ハッシュ付与ロジック
+//! `src/assetsStrategy/**/strategy.json` の `files` フィールドに列挙されたファイルのみ
+//! ハッシュ付きファイル名でコピーする（CDN 長期キャッシュ対象）。
+//! それ以外のファイル（index.html、HTML から直接参照される CSS/JS/画像など）は
+//! ハッシュなしでそのままコピーする。
 //!
 //! ## manifest.json の strategies セクション
 //! `src/assetsStrategy/` 配下のサブディレクトリを走査し、各ディレクトリの
 //! `strategy.json` を読み込んで `manifest.json` の `strategies` セクションに追加する。
 //! フォルダ名が `strategyAssets("name")` の呼び出し名と一致する。
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::path::Path;
 use std::time::Instant;
 
@@ -51,15 +57,35 @@ pub fn run(config: &S3dCliConfig, config_path: &Path) -> Result<()> {
         .with_context(|| format!("アセット収集エラー: {}", src_dir.display()))?;
     println!("  収集: {} ファイル", collected.len().to_string().bold());
 
-    // ── 2. ハッシュ化
+    // ── 2. ハッシュ化（全ファイル対象、コピー時に選別）
     let hashed = hash_assets(&collected, s3d_deploy::hash::DEFAULT_HASH_LENGTH)
         .context("ハッシュ計算エラー")?;
 
-    // ── 3. output/ へハッシュ付きファイルをコピー
+    // ── 3. assetsStrategy の files を収集してハッシュ付与対象セットを構築
+    let strategies_root = src_dir.join("assetsStrategy");
+    let strategies = scan_strategies(&strategies_root)
+        .context("assetsStrategy ディレクトリの走査エラー")?;
+    if !strategies.is_empty() {
+        println!("  strategies: {} 件", strategies.len().to_string().bold());
+    }
+
+    // strategy.json の files に含まれるキーのみハッシュを付与する
+    let hashed_key_set: HashSet<String> = strategies
+        .values()
+        .flat_map(|s| s.files.iter().cloned())
+        .collect();
+
+    // ── 4. output/ へコピー
+    // assetsStrategy の files に含まれるファイル → ハッシュ付きファイル名
+    // それ以外 → 元のキーのまま
     std::fs::create_dir_all(&output_dir)?;
     for asset in &hashed {
-        // hashed_key は "assets/style.abcd1234.css" のような形式
-        let dest = output_dir.join(&asset.hashed_key);
+        let dest_key = if hashed_key_set.contains(&asset.key) {
+            asset.hashed_key.clone()
+        } else {
+            asset.key.clone()
+        };
+        let dest = output_dir.join(&dest_key);
         if let Some(parent) = dest.parent() {
             std::fs::create_dir_all(parent)?;
         }
@@ -72,7 +98,8 @@ pub fn run(config: &S3dCliConfig, config_path: &Path) -> Result<()> {
         })?;
     }
 
-    // ── 4. マニフェスト生成
+    // ── 5. マニフェスト生成
+    // strategy files のみ hashed_key ベースの URL、それ以外は元の key を使用
     let manifest_opts = ManifestOptions {
         cdn_base_url: config
             .storage
@@ -81,19 +108,14 @@ pub fn run(config: &S3dCliConfig, config_path: &Path) -> Result<()> {
             .to_string(),
         version: "1.0.0".to_string(),
         build_time: Some(chrono::Utc::now().to_rfc3339()),
+        hashed_keys: hashed_key_set,
     };
     let mut manifest = build_manifest(&hashed, &manifest_opts).context("マニフェスト生成エラー")?;
 
-    // ── 5. strategies セクションを構築 (src/assetsStrategy/ サブディレクトリ走査)
-    let strategies_root = src_dir.join("assetsStrategy");
-    let strategies = scan_strategies(&strategies_root)
-        .context("assetsStrategy ディレクトリの走査エラー")?;
-    if !strategies.is_empty() {
-        println!("  strategies: {} 件", strategies.len().to_string().bold());
-    }
+    // ── 6. strategies セクションをセット
     manifest.strategies = strategies;
 
-    // ── 6. manifest.json の書き込み
+    // ── 7. manifest.json の書き込み
     let manifest_path = config.resolved_manifest_path();
     let manifest_path = if manifest_path.is_absolute() {
         manifest_path
@@ -296,18 +318,19 @@ mod tests {
             "style.css が含まれていない"
         );
 
-        // output/ にハッシュ付きファイルがコピーされている
+        // strategy files がないので app.js / style.css はハッシュなし
         let output_files: Vec<_> = std::fs::read_dir(dir.path().join("output"))
             .unwrap()
             .filter_map(|e| e.ok())
             .map(|e| e.file_name().to_string_lossy().to_string())
             .collect();
-        // app.abcd1234.js のような形式のファイルが存在する
         assert!(
-            output_files
-                .iter()
-                .any(|f| f.contains("app") && f.ends_with(".js")),
-            "ハッシュ付き app.js が output/ に存在しない: {output_files:?}"
+            output_files.contains(&"app.js".to_string()),
+            "ハッシュなし app.js が output/ にあるべき: {output_files:?}"
+        );
+        assert!(
+            output_files.contains(&"style.css".to_string()),
+            "ハッシュなし style.css が output/ にあるべき: {output_files:?}"
         );
     }
 
@@ -413,5 +436,132 @@ mod tests {
         assert!(!files.is_empty(), "files が空");
         assert_eq!(sushi["cache"].as_bool(), Some(true));
         assert_eq!(sushi["maxAge"].as_str(), Some("7d"));
+    }
+
+    #[test]
+    fn test_build_strategy_files_get_hash_others_dont() {
+        // assetsStrategy files に含まれるファイル → ハッシュあり
+        // それ以外 → ハッシュなし
+        let dir = TempDir::new().unwrap();
+        let src = dir.path().join("src");
+        let assets_dir = src.join("assets");
+        let strategy_dir = src.join("assetsStrategy").join("sushi");
+        std::fs::create_dir_all(&assets_dir).unwrap();
+        std::fs::create_dir_all(&strategy_dir).unwrap();
+
+        // strategy files に含まれる GLB
+        std::fs::write(assets_dir.join("sushi.glb"), b"glb-data").unwrap();
+        // strategy files に含まれない通常ファイル
+        std::fs::write(src.join("index.html"), b"<!DOCTYPE html>").unwrap();
+        std::fs::write(assets_dir.join("style.css"), b"body{}").unwrap();
+
+        std::fs::write(
+            strategy_dir.join("strategy.json"),
+            r#"{"files":["assets/sushi.glb"],"initial":false,"cache":true}"#,
+        )
+        .unwrap();
+
+        let config_path = dir.path().join("s3d.config.json");
+        let cfg = make_config("src");
+        crate::config::save_config(&config_path, &cfg).unwrap();
+
+        run(&cfg, &config_path).unwrap();
+
+        // output/assets/ 以下を収集
+        let output_assets: Vec<_> = std::fs::read_dir(dir.path().join("output/assets"))
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .map(|e| e.file_name().to_string_lossy().to_string())
+            .collect();
+        let output_root: Vec<_> = std::fs::read_dir(dir.path().join("output"))
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .map(|e| e.file_name().to_string_lossy().to_string())
+            .collect();
+
+        // sushi.glb はハッシュ付き
+        assert!(
+            output_assets.iter().any(|f| f.starts_with("sushi.") && f.ends_with(".glb") && f != "sushi.glb"),
+            "sushi.glb にハッシュが付くべき: {:?}", output_assets
+        );
+        // style.css はハッシュなし
+        assert!(
+            output_assets.contains(&"style.css".to_string()),
+            "style.css はハッシュなしのまま: {:?}", output_assets
+        );
+        // index.html はハッシュなし
+        assert!(
+            output_root.contains(&"index.html".to_string()),
+            "index.html はハッシュなしのまま: {:?}", output_root
+        );
+
+        // manifest の URL 確認
+        let content = std::fs::read_to_string(dir.path().join("output/manifest.json")).unwrap();
+        let v: serde_json::Value = serde_json::from_str(&content).unwrap();
+        let assets = v["assets"].as_object().unwrap();
+
+        // sushi.glb の URL にはハッシュが入る
+        let sushi_url = assets["assets/sushi.glb"]["url"].as_str().unwrap();
+        assert!(
+            sushi_url.contains('.') && !sushi_url.ends_with("/assets/sushi.glb"),
+            "sushi.glb URL にハッシュが入るべき: {sushi_url}"
+        );
+        // style.css の URL はハッシュなし
+        let css_url = assets["assets/style.css"]["url"].as_str().unwrap();
+        assert!(
+            css_url.ends_with("/assets/style.css"),
+            "style.css URL にハッシュが入ってはならない: {css_url}"
+        );
+        // index.html の URL はハッシュなし
+        let html_url = assets["index.html"]["url"].as_str().unwrap();
+        assert!(
+            html_url.ends_with("/index.html"),
+            "index.html URL にハッシュが入ってはならない: {html_url}"
+        );
+    }
+
+    #[test]
+    fn test_build_excludes_gitkeep_and_assets_strategy() {
+        let dir = TempDir::new().unwrap();
+        let src = dir.path().join("src");
+        let assets_dir = src.join("assets");
+        let strategy_dir = src.join("assetsStrategy").join("sushi");
+        std::fs::create_dir_all(&assets_dir).unwrap();
+        std::fs::create_dir_all(&strategy_dir).unwrap();
+
+        // .gitkeep と assetsStrategy/ 配下は collect から除外される
+        std::fs::write(assets_dir.join(".gitkeep"), b"").unwrap();
+        std::fs::write(strategy_dir.join("strategy.json"), b"{\"files\":[],\"initial\":false,\"cache\":true}").unwrap();
+        std::fs::write(assets_dir.join("hero.png"), b"png-data").unwrap();
+
+        let config_path = dir.path().join("s3d.config.json");
+        let cfg = make_config("src");
+        crate::config::save_config(&config_path, &cfg).unwrap();
+
+        run(&cfg, &config_path).unwrap();
+
+        let manifest_path = dir.path().join("output/manifest.json");
+        let content = std::fs::read_to_string(&manifest_path).unwrap();
+        let v: serde_json::Value = serde_json::from_str(&content).unwrap();
+        let assets = v["assets"].as_object().unwrap();
+
+        // .gitkeep はマニフェストに含まれない
+        assert!(
+            !assets.keys().any(|k| k.contains(".gitkeep")),
+            ".gitkeep がマニフェストに含まれていてはならない: {:?}",
+            assets.keys().collect::<Vec<_>>()
+        );
+        // assetsStrategy/ 配下もマニフェストの assets に含まれない
+        assert!(
+            !assets.keys().any(|k| k.starts_with("assetsStrategy")),
+            "assetsStrategy/ がマニフェストの assets に含まれていてはならない: {:?}",
+            assets.keys().collect::<Vec<_>>()
+        );
+        // hero.png は含まれる
+        assert!(
+            assets.keys().any(|k| k.contains("hero.png")),
+            "hero.png がマニフェストに含まれるべき: {:?}",
+            assets.keys().collect::<Vec<_>>()
+        );
     }
 }

--- a/crates/s3d-deploy/src/collect.rs
+++ b/crates/s3d-deploy/src/collect.rs
@@ -79,10 +79,19 @@ fn build_globset(patterns: &[String]) -> Result<Option<GlobSet>, CollectError> {
     })?))
 }
 
+/// デフォルトで常に除外するパターン
+///
+/// - `.gitkeep` — 空ディレクトリ保持用ファイル
+/// - `assetsStrategy/**` — 戦略定義は manifest に取り込み済みなので CDN に配信しない
+const DEFAULT_IGNORE_PATTERNS: &[&str] = &[
+    "**/.gitkeep",
+    "assetsStrategy/**",
+];
+
 /// アセット収集オプション
 #[derive(Debug, Clone, Default)]
 pub struct CollectOptions {
-    /// 除外する glob パターン（case-insensitive）
+    /// 除外する glob パターン（case-insensitive）。DEFAULT_IGNORE_PATTERNS と合算される
     pub ignore: Vec<String>,
     /// 明示的に含める glob パターン。空の場合はすべて対象
     pub include: Vec<String>,
@@ -100,7 +109,13 @@ pub fn collect(
     root_dir: &Path,
     opts: &CollectOptions,
 ) -> Result<Vec<CollectedAsset>, CollectError> {
-    let ignore_set = build_globset(&opts.ignore)?;
+    // デフォルト除外パターン + ユーザー指定パターンを合算
+    let combined_ignore: Vec<String> = DEFAULT_IGNORE_PATTERNS
+        .iter()
+        .map(|s| s.to_string())
+        .chain(opts.ignore.iter().cloned())
+        .collect();
+    let ignore_set = build_globset(&combined_ignore)?;
     let include_set = build_globset(&opts.include)?;
     let max_bytes = opts.max_file_size.as_deref().and_then(parse_max_file_size);
 
@@ -190,6 +205,56 @@ mod tests {
         let keys: Vec<_> = assets.iter().map(|a| a.key.as_str()).collect();
         assert!(keys.contains(&"a.js"));
         assert!(keys.contains(&"sub/b.css"));
+    }
+
+    #[test]
+    fn collect_excludes_gitkeep_by_default() {
+        let tmp = TempDir::new().unwrap();
+        make_file(tmp.path(), "assets/.gitkeep", b"");
+        make_file(tmp.path(), "assets/main.js", b"x");
+
+        let assets = collect(tmp.path(), &CollectOptions::default()).unwrap();
+        let keys: Vec<_> = assets.iter().map(|a| a.key.as_str()).collect();
+        assert!(!keys.iter().any(|k| k.contains(".gitkeep")), ".gitkeep は除外されるべき: {keys:?}");
+        assert!(keys.contains(&"assets/main.js"));
+    }
+
+    #[test]
+    fn collect_excludes_assets_strategy_by_default() {
+        let tmp = TempDir::new().unwrap();
+        make_file(tmp.path(), "assetsStrategy/strategy.json", b"{}");
+        make_file(tmp.path(), "assetsStrategy/sushi/strategy.json", b"{}");
+        make_file(tmp.path(), "assets/hero.png", b"img");
+
+        let assets = collect(tmp.path(), &CollectOptions::default()).unwrap();
+        let keys: Vec<_> = assets.iter().map(|a| a.key.as_str()).collect();
+        assert!(
+            !keys.iter().any(|k| k.starts_with("assetsStrategy")),
+            "assetsStrategy/ は除外されるべき: {keys:?}"
+        );
+        assert!(keys.contains(&"assets/hero.png"));
+    }
+
+    #[test]
+    fn collect_user_ignore_combined_with_defaults() {
+        let tmp = TempDir::new().unwrap();
+        make_file(tmp.path(), "assets/.gitkeep", b"");
+        make_file(tmp.path(), "assetsStrategy/sushi/strategy.json", b"{}");
+        make_file(tmp.path(), "assets/main.js", b"x");
+        make_file(tmp.path(), "assets/style.css", b"x");
+        make_file(tmp.path(), "assets/main.js.map", b"{}");
+
+        let opts = CollectOptions {
+            ignore: vec!["**/*.map".to_string()],
+            ..Default::default()
+        };
+        let assets = collect(tmp.path(), &opts).unwrap();
+        let keys: Vec<_> = assets.iter().map(|a| a.key.as_str()).collect();
+        assert!(!keys.iter().any(|k| k.contains(".gitkeep")));
+        assert!(!keys.iter().any(|k| k.starts_with("assetsStrategy")));
+        assert!(!keys.iter().any(|k| k.ends_with(".map")));
+        assert!(keys.contains(&"assets/main.js"));
+        assert!(keys.contains(&"assets/style.css"));
     }
 
     #[test]

--- a/crates/s3d-deploy/src/manifest.rs
+++ b/crates/s3d-deploy/src/manifest.rs
@@ -7,7 +7,7 @@
 //! glTF アセット (`.gltf` / `.glb`) の依存関係（`.bin` / テクスチャ）は
 //! ファイル内容を解析して自動的にマッピングする。
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 
 use s3d_types::asset::HashedAsset;
@@ -105,6 +105,9 @@ pub struct ManifestOptions {
     pub version: String,
     /// ビルド日時（RFC3339）。`None` の場合は現在時刻の代わりに空文字を使う
     pub build_time: Option<String>,
+    /// ハッシュを付与するファイルキーのセット（assetsStrategy の files に含まれるもの）
+    /// 一致するファイルは hashed_key を URL に使用し、それ以外は元の key をそのまま使用する
+    pub hashed_keys: HashSet<String>,
 }
 
 /// [`HashedAsset`] のリストから [`DeployManifest`] を構築する。
@@ -125,7 +128,13 @@ pub fn build_manifest(
     let mut entries: HashMap<String, AssetEntry> = HashMap::new();
 
     for asset in assets {
-        let url = format!("{}/{}", base, asset.hashed_key);
+        // hashed_keys に含まれるファイルのみハッシュ付き URL、それ以外は元のキーをそのまま使う
+        let url_path = if opts.hashed_keys.contains(&asset.key) {
+            asset.hashed_key.clone()
+        } else {
+            asset.key.clone()
+        };
+        let url = format!("{}/{}", base, url_path);
         let content_type = guess_content_type(&asset.key);
 
         // glTF JSON の依存関係解析
@@ -201,19 +210,21 @@ mod tests {
 
         let assets = vec![make_hashed("js/main.js", "abcd1234", 14, js_path)];
 
+        let mut hashed_keys = HashSet::new();
+        hashed_keys.insert("js/main.js".to_string());
         let opts = ManifestOptions {
             cdn_base_url: "https://cdn.example.com".to_string(),
             version: "1.0.0".to_string(),
             build_time: Some("2026-03-20T00:00:00Z".to_string()),
+            hashed_keys,
         };
-
         let manifest = build_manifest(&assets, &opts).unwrap();
-        assert_eq!(manifest.schema_version, 1);
         assert_eq!(manifest.version, "1.0.0");
         // キーは元のパス（ハッシュなし）
         assert!(manifest.assets.contains_key("js/main.js"));
 
         let entry = &manifest.assets["js/main.js"];
+        // hashed_keys に含まれるので hashed_key ベースの URL
         assert_eq!(entry.url, "https://cdn.example.com/js/main.abcd1234.js");
         // mime_guess は "text/javascript" または "application/javascript" を返す
         assert!(entry.content_type.contains("javascript"));
@@ -248,6 +259,7 @@ mod tests {
             cdn_base_url: "https://cdn.test".to_string(),
             version: "0.1.0".to_string(),
             build_time: Some("2026-01-01T00:00:00Z".to_string()),
+            hashed_keys: HashSet::new(),
         };
         let manifest = build_manifest(&assets, &opts).unwrap();
         let json = manifest_to_json(&manifest).unwrap();
@@ -284,10 +296,14 @@ mod tests {
             make_hashed("buffer.bin", "bbbb0002", 16, bin_path),
         ];
 
+        let mut hashed_keys = HashSet::new();
+        hashed_keys.insert("scene.gltf".to_string());
+        hashed_keys.insert("buffer.bin".to_string());
         let opts = ManifestOptions {
             cdn_base_url: "https://cdn.example.com".to_string(),
             version: "1.0.0".to_string(),
             build_time: None,
+            hashed_keys,
         };
 
         let manifest = build_manifest(&assets, &opts).unwrap();

--- a/crates/s3d-deploy/tests/pipeline.rs
+++ b/crates/s3d-deploy/tests/pipeline.rs
@@ -45,6 +45,7 @@ fn pipeline_collect_hash_manifest() {
         cdn_base_url: "https://cdn.example.com".to_string(),
         version: "1.0.0".to_string(),
         build_time: Some("2026-03-20T00:00:00Z".to_string()),
+        hashed_keys: std::collections::HashSet::new(),
     };
     let manifest = build_manifest(&hashed, &manifest_opts).unwrap();
     assert_eq!(manifest.schema_version, 1);
@@ -79,6 +80,7 @@ fn pipeline_diff_second_deploy() {
         cdn_base_url: "https://cdn.example.com".to_string(),
         version: "1.0.0".to_string(),
         build_time: None,
+        hashed_keys: std::collections::HashSet::new(),
     };
     let manifest_v1 = build_manifest(&hashed, &manifest_opts).unwrap();
 
@@ -104,6 +106,7 @@ fn gltf_dependencies_resolved_in_manifest() {
         cdn_base_url: "https://cdn.example.com".to_string(),
         version: "1.0.0".to_string(),
         build_time: None,
+        hashed_keys: std::collections::HashSet::new(),
     };
     let manifest = build_manifest(&hashed, &manifest_opts).unwrap();
 


### PR DESCRIPTION
## Summary

Issue #23 コメントに基づき、ハッシュ付与ロジックを根本的に変更。

### 変更方針

**旧実装**: 全ファイルにハッシュ → `noHash` で例外指定（index.html のみ除外）  
**新実装**: `assetsStrategy` の `files` に登録されたファイルのみハッシュを付与

---

### 1. strategy-based ハッシュ判定

`build` 時に `src/assetsStrategy/**/strategy.json` を走査し、  
`files` フィールドに含まれるキーを `HashSet` に収集。

| ファイル | 判定 | 理由 |
|---|---|---|
| `assets/sushi.glb` (strategy files に含む) | **ハッシュあり** | CDN 長期キャッシュ対象 |
| `index.html` | **ハッシュなし** | HTML から直接参照 |
| `assets/style.css` | **ハッシュなし** | HTML から直接参照 |
| `assets/main.js` | **ハッシュなし** | HTML から直接参照 |

### 期待される `output/` 構造

```
output/
  index.html              ← ハッシュなし
  manifest.json
  assets/
    style.css             ← ハッシュなし（HTML で直接参照）
    main.js               ← ハッシュなし
    hero.png              ← ハッシュなし
    sushi.abcd1234.glb    ← ハッシュあり（assetsStrategy で管理）
```

---

### 2. デフォルト除外ルール（変更なし）

`collect.rs` の `DEFAULT_IGNORE_PATTERNS`:
- `**/.gitkeep` — 空ディレクトリ保持用ファイルを除外
- `assetsStrategy/**` — 戦略定義ファイルを CDN 配信から除外

---

### 3. `noHash` 設定の廃止

不要になったため削除:
- `S3dCliConfig.no_hash` フィールド削除
- `ManifestOptions.no_hash_set` (GlobSet) → `hashed_keys` (HashSet<String>) に変更
- `s3d-cli` の `globset` 依存を削除

---

## 変更ファイル

- **`build.rs`**: scan_strategies() で files 収集 → HashSet でハッシュ判定
- **`manifest.rs`**: `hashed_keys: HashSet<String>` で URL パス選択
- **`config.rs`**: `no_hash` フィールド・`default_no_hash()` 関数削除
- **`Cargo.toml`** (s3d-cli): `globset` 依存削除
- **`init.rs` / `push.rs` / `validate.rs`**: `S3dCliConfig` リテラルから `no_hash` 削除
- **`pipeline.rs`**: `ManifestOptions` の `no_hash_set` → `hashed_keys` に更新

## Tests

- `test_build_strategy_files_get_hash_others_dont` — 新ロジックの統合テスト（メインケース）
- `test_build_excludes_gitkeep_and_assets_strategy` — デフォルト除外テスト
- `test_build_creates_manifest_and_hashed_files` — strategy なし時は全ファイルハッシュなし

**Test result: 50 passed, 0 failed, 1 ignored** (s3d-cli)