### PR TITLE
fix(push): #34 loader.js 常時アップロード / #36 R2 ハッシュ付きキー修正 — Closes #34 Closes #36

### DIFF
--- a/crates/s3d-cli/src/commands/push.rs
+++ b/crates/s3d-cli/src/commands/push.rs
@@ -134,46 +134,55 @@ pub async fn run(
                 async move {
                     let entry = new_manifest.assets.get(&key);
 
-                    // manifest.assets[key].url からファイルパスを解決する。
+                    // manifest.assets[key].url からハッシュ付きパスを取り出す。
+                    // このパスは:
+                    //   1. ローカルファイルの読み込みパス (output/<path>)
+                    //   2. R2 へのアップロードキー
+                    // の両方に使う。
+                    //
                     // rewrite_urls_to_cdn 後の URL 例:
                     //   "https://cdn.example.com/assets/cake-3d.30e14955.bin"
-                    // の場合、パス部分 "assets/cake-3d.30e14955.bin" を使う。
-                    // 相対 URL "/assets/cake-3d.30e14955.bin" の場合も先頭 '/' を除去して使う。
-                    let local_path = entry.and_then(|e| {
+                    //   → path = "assets/cake-3d.30e14955.bin"
+                    // 相対 URL の場合:
+                    //   "/assets/cake-3d.30e14955.bin"
+                    //   → path = "assets/cake-3d.30e14955.bin"
+                    let url_path = entry.and_then(|e| {
                         let url = &e.url;
-                        // http(s):// の場合はパス部分のみ取り出す
                         if url.starts_with("http://") || url.starts_with("https://") {
+                            // "https://cdn.example.com/assets/foo.hash.bin" → "assets/foo.hash.bin"
                             url.splitn(4, '/').nth(3).map(|p| p.to_string())
                         } else {
-                            // ルート相対 URL ("/assets/...") の場合
+                            // "/assets/foo.hash.bin" → "assets/foo.hash.bin"
                             Some(url.trim_start_matches('/').to_string())
                         }
                     });
 
-                    let file_path = match local_path {
-                        Some(ref p) => output_dir.join(p),
-                        None => output_dir.join(&key), // フォールバック: 論理キーで探す
-                    };
+                    // R2 アップロードキー: URL のパス部分（ハッシュ付き）
+                    // フォールバック: 論理キー（ハッシュなし、後方互換）
+                    let upload_key = url_path.clone().unwrap_or_else(|| key.clone());
+                    let file_path = output_dir.join(&upload_key);
 
                     match std::fs::read(&file_path) {
                         Ok(data) => {
                             let content_type = entry
                                 .map(|e| e.content_type.as_str())
                                 .unwrap_or("application/octet-stream");
-                            match storage.put(&key, &data, content_type).await {
+                            // storage.put の第1引数はハッシュ付きキー（manifest の URL パス部分）
+                            // ブラウザが要求する URL と R2 オブジェクトキーを一致させる
+                            match storage.put(&upload_key, &data, content_type).await {
                                 Ok(_) => {
                                     let done = counter
                                         .fetch_add(1, std::sync::atomic::Ordering::Relaxed)
                                         + 1;
-                                    eprintln!("  [{done}/{total}] {} {key}", "↑".green());
+                                    eprintln!("  [{done}/{total}] {} {upload_key}", "↑".green());
                                 }
                                 Err(e) => {
-                                    eprintln!("  {} {key}: {}", "✘".red(), e.message);
+                                    eprintln!("  {} {upload_key}: {}", "✘".red(), e.message);
                                 }
                             }
                         }
                         Err(e) => {
-                            eprintln!("  {} ファイル読み込み失敗 {key} ({}): {e}", "✘".red(), file_path.display());
+                            eprintln!("  {} ファイル読み込み失敗 {upload_key} ({}): {e}", "✘".red(), file_path.display());
                         }
                     }
                 }
@@ -490,6 +499,14 @@ mod tests {
             "push 後の manifest.json の URL は CDN 絶対 URL であるべき: {url}"
         );
         assert_eq!(url, "https://cdn.example.com/app.abcd1234.js");
+
+        // R2 にはハッシュ付きキーで保存されている（論理キーではない）
+        let r2_data = storage.get("app.abcd1234.js").await
+            .expect("R2 のキーはハッシュ付き app.abcd1234.js であるべき");
+        assert_eq!(r2_data, b"console.log(1);");
+        // 論理キーでは保存されていない
+        assert!(storage.get("app.js").await.is_err(),
+            "論理キー app.js で R2 に保存されていてはならない");
     }
 
     #[tokio::test]
@@ -549,6 +566,13 @@ mod tests {
         let uploaded = storage.get("loader.js").await
             .expect("loader.js がストレージにアップロードされていない");
         assert_eq!(uploaded, loader_content, "loader.js の内容が一致しない");
+
+        // アセットはハッシュ付きキーで R2 に保存されている
+        let asset_data = storage.get("app.abcd1234.js").await
+            .expect("R2 のキーはハッシュ付き app.abcd1234.js であるべき");
+        assert_eq!(asset_data, b"console.log(1);");
+        assert!(storage.get("app.js").await.is_err(),
+            "論理キー app.js で R2 に保存されていてはならない");
     }
 
     #[tokio::test]
@@ -631,5 +655,79 @@ mod tests {
         let uploaded = storage.get("loader.js").await
             .expect("変更なし時でも loader.js はアップロードされるべき");
         assert_eq!(uploaded, loader_content, "loader.js の内容が一致しない");
+    }
+
+    #[tokio::test]
+    async fn test_push_uses_hashed_key_for_r2() {
+        // Issue #36: R2 アップロードキーが論理キーではなくハッシュ付きパスになることを確認
+        // storage.put(&key, ...) → storage.put(&upload_key, ...) の修正を検証
+        use s3d_types::manifest::{AssetEntry, DeployManifest};
+        use tempfile::TempDir;
+
+        let dir = TempDir::new().unwrap();
+        let output = dir.path().join("output");
+        let assets_dir = output.join("assets");
+        std::fs::create_dir_all(&assets_dir).unwrap();
+
+        // ハッシュ付きファイルを output/ に配置（s3d build が生成する状態を模倣）
+        let glb_data = b"glb-binary-data";
+        std::fs::write(assets_dir.join("cake-3d.30e14955.bin"), glb_data).unwrap();
+
+        let mut assets = HashMap::new();
+        assets.insert(
+            "assets/cake-3d.bin".to_string(), // 論理キー
+            AssetEntry {
+                url: "/assets/cake-3d.30e14955.bin".to_string(), // ハッシュ付き相対 URL
+                size: glb_data.len() as u64,
+                hash: "30e14955".to_string(),
+                content_type: "application/octet-stream".to_string(),
+                dependencies: None,
+            },
+        );
+        let manifest = DeployManifest {
+            schema_version: 1,
+            version: "1.0.0".to_string(),
+            build_time: "2026-01-01T00:00:00Z".to_string(),
+            assets,
+            strategies: HashMap::new(),
+        };
+        let manifest_path = output.join("manifest.json");
+        std::fs::write(
+            &manifest_path,
+            serde_json::to_string_pretty(&manifest).unwrap(),
+        )
+        .unwrap();
+
+        let cfg_path = dir.path().join("s3d.config.json");
+        let cfg = make_config(); // cdn_base_url = "https://cdn.example.com"
+        crate::config::save_config(&cfg_path, &cfg).unwrap();
+
+        let storage = Arc::new(MockStorage::new());
+        let storage_dyn: Arc<dyn StoragePlugin> = storage.clone();
+
+        run(&cfg, &cfg_path, Some(&manifest_path), false, Arc::clone(&storage_dyn))
+            .await
+            .unwrap();
+
+        // ハッシュ付きキーで R2 にアップロードされている
+        let r2_data = storage.get("assets/cake-3d.30e14955.bin").await
+            .expect("R2 のキーはハッシュ付き assets/cake-3d.30e14955.bin であるべき");
+        assert_eq!(r2_data, glb_data);
+
+        // 論理キーでは保存されていない（ブラウザが参照する URL と異なるため）
+        assert!(
+            storage.get("assets/cake-3d.bin").await.is_err(),
+            "論理キー assets/cake-3d.bin で R2 に保存されていてはならない"
+        );
+
+        // manifest.json の URL が CDN 絶対 URL になっている
+        let manifest_bytes = storage.get("manifest.json").await.unwrap();
+        let uploaded_manifest: DeployManifest = serde_json::from_slice(&manifest_bytes).unwrap();
+        let url = &uploaded_manifest.assets["assets/cake-3d.bin"].url;
+        assert_eq!(
+            url,
+            "https://cdn.example.com/assets/cake-3d.30e14955.bin",
+            "manifest の URL が CDN 絶対 URL + ハッシュ付きであるべき"
+        );
     }
 }


### PR DESCRIPTION
## 概要

Issue #34 と Issue #36 の修正をまとめた PR です。

---

## Issue #34（コメント対応） — loader.js を変更なし early return の前にアップロード

### 問題
loader.js のアップロードが「変更なし」early return の後に配置されていたため、  
初回 push / アセット変更なし時に一度もアップロードされず CDN 上で 404 になる。

### 修正
loader.js アップロードを差分計算・early return の**前**に移動。

```
【変更後の処理順序】
1. loader.js をアップロード  ← 常に実行（dry_run=false のみ）
2. 差分計算
3. 変更なし → return
4. 変更あり → アセットアップロード → 削除 → manifest.json アップロード
```

---

## Issue #36 — R2 アップロードキーをハッシュ付きパスに修正

### 問題
`storage.put` の第1引数に manifest の論理キー（例: `assets/cake-3d.bin`）を使っていたため、  
R2 上のオブジェクトキーとブラウザが要求する URL が一致せず 404 になる。

```
ブラウザの要求: https://cdn.example.com/assets/cake-3d.30e14955.bin
R2 のキー:      assets/cake-3d.bin  ← 不一致 → 404
```

### 修正
```rust
// 変更前
storage.put(&key, &data, content_type)        // 論理キー

// 変更後
storage.put(&upload_key, &data, content_type) // ハッシュ付きキー（URL のパス部分）
```

`upload_key` = `manifest.assets[key].url` のパス部分
- `https://cdn.example.com/assets/cake-3d.30e14955.bin` → `assets/cake-3d.30e14955.bin`
- `/assets/cake-3d.30e14955.bin` → `assets/cake-3d.30e14955.bin`

---

## テスト結果

| | 結果 |
|---|---|
| Rust (`cargo test --workspace`) | **59 passed, 0 failed**, 1 ignored |
| TypeScript (`npm test`) | **23 passed, 0 failed** |

## 変更ファイル

- `crates/s3d-cli/src/commands/push.rs`